### PR TITLE
Add minsize as a pen setting (defaulting to 1).

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -126,9 +126,9 @@ void on_monitors_changed ( GdkScreen *screen,
 
 
   data->default_pen = paint_context_new (data, GROMIT_PEN,
-					 data->red, 7, 0);
+					 data->red, 7, 0, 1);
   data->default_eraser = paint_context_new (data, GROMIT_ERASER,
-					    data->red, 75, 0);
+					    data->red, 75, 0, 1);
 
   if(!data->composited) // set shape
     {
@@ -269,8 +269,10 @@ gboolean on_buttonpress (GtkWidget *win,
   else
     {
       gdk_event_get_axis ((GdkEvent *) ev, GDK_AXIS_PRESSURE, &pressure);
-      data->maxwidth = (CLAMP (pressure * pressure + line_thickener,0,1) *
-                        (double) slavedata->cur_context->width);
+      data->maxwidth = (CLAMP (pressure + line_thickener, 0, 1) *
+                        (double) (slavedata->cur_context->width -
+				  slavedata->cur_context->minwidth) +
+			slavedata->cur_context->minwidth);
     }
   if (ev->button <= 5)
     draw_line (data, slave, ev->x, ev->y, ev->x, ev->y);
@@ -333,8 +335,10 @@ gboolean on_motion (GtkWidget *win,
               if (gdk_device_get_source(slave) == GDK_SOURCE_MOUSE)
                 data->maxwidth = slavedata->cur_context->width;
               else
-                data->maxwidth = (CLAMP (pressure * pressure + line_thickener, 0, 1) *
-                                  (double) slavedata->cur_context->width);
+		data->maxwidth = (CLAMP (pressure + line_thickener, 0, 1) *
+				  (double) (slavedata->cur_context->width -
+					    slavedata->cur_context->minwidth) +
+				  slavedata->cur_context->minwidth);
 
               gdk_device_get_axis(slave, coords[i]->axes,
                                   GDK_AXIS_X, &x);
@@ -361,8 +365,10 @@ gboolean on_motion (GtkWidget *win,
       if (gdk_device_get_source(slave) == GDK_SOURCE_MOUSE)
 	data->maxwidth = slavedata->cur_context->width;
       else
-        data->maxwidth = (CLAMP (pressure * pressure + line_thickener,0,1) *
-                          (double)slavedata->cur_context->width);
+	data->maxwidth = (CLAMP (pressure + line_thickener, 0, 1) *
+			  (double) (slavedata->cur_context->width -
+				    slavedata->cur_context->minwidth) +
+			  slavedata->cur_context->minwidth);
 
       if(slavedata->motion_time > 0)
 	{

--- a/src/gromit-mpx.c
+++ b/src/gromit-mpx.c
@@ -39,7 +39,8 @@ GromitPaintContext *paint_context_new (GromitData *data,
 				       GromitPaintType type,
 				       GdkColor *paint_color, 
 				       guint width,
-				       guint arrowsize)
+				       guint arrowsize,
+				       guint minwidth)
 {
   GromitPaintContext *context;
 
@@ -48,6 +49,7 @@ GromitPaintContext *paint_context_new (GromitData *data,
   context->type = type;
   context->width = width;
   context->arrowsize = arrowsize;
+  context->minwidth = minwidth;
   context->paint_color = paint_color;
 
   
@@ -89,6 +91,7 @@ void paint_context_print (gchar *name,
   }
 
   g_printerr ("width: %3d, ", context->width);
+  g_printerr ("minwidth: %3d, ", context->minwidth);
   g_printerr ("arrowsize: %.2f, ", context->arrowsize);
   g_printerr ("color: #%02X%02X%02X\n", context->paint_color->red >> 8,
               context->paint_color->green >> 8, context->paint_color->blue >> 8);
@@ -858,9 +861,9 @@ void setup_main_app (GromitData *data, gboolean activate)
   data->modified = 0;
 
   data->default_pen = paint_context_new (data, GROMIT_PEN,
-					 data->red, 7, 0);
+					 data->red, 7, 0, 1);
   data->default_eraser = paint_context_new (data, GROMIT_ERASER,
-					    data->red, 75, 0);
+					    data->red, 75, 0, 1);
 
   
 

--- a/src/gromit-mpx.h
+++ b/src/gromit-mpx.h
@@ -66,6 +66,7 @@ typedef struct
   GromitPaintType type;
   guint           width;
   gfloat          arrowsize;
+  guint           minwidth;
   GdkColor        *paint_color;
   cairo_t         *paint_ctx;
   gdouble         pressure;
@@ -173,7 +174,8 @@ void coord_list_free (GromitData *data, GdkDevice* dev);
 
 
 GromitPaintContext *paint_context_new (GromitData *data, GromitPaintType type,
-				       GdkColor *fg_color, guint width, guint arrowsize);
+				       GdkColor *fg_color, guint width, guint arrowsize,
+                                       guint minwidth);
 void paint_context_free (GromitPaintContext *context);
 
 


### PR DESCRIPTION
This allows to set the pressure response within minsize/size. Since the default wacom driver already allows to tune the response curve, I removed the quadratic function which made the pen hardly usable for me. With this it has now the typical response I get by default in other programs.

I set the default minsize to 1. Arguably, the default pen should have something larger than 7 pixels for use with a stylus, but I don't know how it would behave with finger pressure where I guess 7 is a good compromise.