### PR TITLE
drawing: always draw if minwidth > 0

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -309,7 +309,7 @@ gboolean on_motion (GtkWidget *win,
 
           gdk_device_get_axis (ev->device, coords[i]->axes,
                                GDK_AXIS_PRESSURE, &pressure);
-          if (pressure > 0)
+          if (pressure > 0 || devdata->cur_context->minwidth > 0)
             {
 	      data->maxwidth = (CLAMP (pressure + line_thickener, 0, 1) *
 				(double) (devdata->cur_context->width -
@@ -336,7 +336,7 @@ gboolean on_motion (GtkWidget *win,
   /* always paint to the current event coordinate. */
   gdk_event_get_axis ((GdkEvent *) ev, GDK_AXIS_PRESSURE, &pressure);
 
-  if (pressure > 0)
+  if (pressure > 0 || devdata->cur_context->minwidth > 0)
     {
       data->maxwidth = (CLAMP (pressure + line_thickener, 0, 1) *
 			(double) (devdata->cur_context->width -


### PR DESCRIPTION
This allows to use side buttons on styluses to draw/erase/recolor
without pressing down on the stylus. In such cases, button down/up
events are reported, while pressure == 0.

This provides one method to deal with #16.