### PR TITLE
Disabled event compression to make better quality.

### DIFF
--- a/src/gromit-mpx.c
+++ b/src/gromit-mpx.c
@@ -244,6 +244,7 @@ void show_window (GromitData *data)
         g_printerr ("DEBUG: Showing window.\n");
     }
   gdk_window_raise (gtk_widget_get_window(data->win));
+  gdk_window_set_event_compression(gtk_widget_get_window(data->win), FALSE);
 }
 
 


### PR DESCRIPTION
If you'll disable event compression lines will become a lot smoother and pressure sensitivity is not so step-wise.

![output](https://user-images.githubusercontent.com/9720950/83327970-92c72c80-a288-11ea-9ad2-f4cd09c6db30.gif)

On fast lines change is really visible:

![output](https://user-images.githubusercontent.com/9720950/83328113-5c3de180-a289-11ea-8fbf-9b7f914cfc40.gif)
![output](https://user-images.githubusercontent.com/9720950/83328164-a757f480-a289-11ea-95e7-89890d012f14.gif)
