### PR TITLE
Add arrow positioning option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Tobias Schönberg <tobias47n9e@gmail.com>
 Yuri D'Elia <yuri.delia@eurac.edu>
 Julián Unrrein <junrrein@gmail.com>
 Eshant Gupta <guptaeshant@gmail.com>
+Renato Lima <natenho@gmail.com>

--- a/README.md
+++ b/README.md
@@ -166,11 +166,19 @@ not allowed to change size:
 
 	"red fixed Marker" = "red Pen" (minsize=10 maxsize=10);
 
-You can also draw lines that end in an arrow head. For this you
+You can also draw lines that start/end in an arrow head. For this you
 have to specify `arrowsize`. This is a factor relative to the width
 of the line. For reasonable arrowheads start with 1.
 
     "blue Pen" = "blue Arrow" (arrowsize=2);
+
+Arrows can also be positioned at the start, end or both sides of
+a line. Specify `arrowposition` with one of possible values (`start`, `end`, `both`, `none`)
+
+    "blue Pen" = "blue Arrow" (arrowsize=1 arrowposition="start");
+    "blue Pen" = "blue Arrow" (arrowsize=1 arrowposition="end");
+    "blue Pen" = "blue Arrow" (arrowsize=1 arrowposition="both");
+    "blue Pen" = "blue Arrow" (arrowsize=1 arrowposition="none");
 
 An `ERASER` is a tool that erases the drawings on screen.
 The color parameter is not important.
@@ -218,7 +226,7 @@ The decision which tool to use follows a simple policy:
       The same logic holds for the buttons.
 5. Slave device config takes precedence over master device config, which
    in turn takes precedence over the fallback default config.
-   
+
 For versions > 1.3, you can also change the [hotkeys from the config](data/gromit-mpx.cfg#L5)
 file by setting the respective `HOTKEY` and/or `UNDOKEY` values.
 

--- a/data/gromit-mpx.cfg
+++ b/data/gromit-mpx.cfg
@@ -1,4 +1,4 @@
-# Default gromit-mpx configuration 
+# Default gromit-mpx configuration
 # taken from  Totem's telestrator mode config
 # added default entries
 
@@ -6,16 +6,16 @@
 # HOTKEY = "F9";
 # UNDOKEY = "F8";
 
-"red Pen" = PEN (size=5 color="red");				
-"blue Pen" = "red Pen" (color="blue");				
-"yellow Pen" = "red Pen" (color="yellow");			
-"green Marker" = PEN (size=6 color="green" arrowsize=1);		
-									
-"Eraser" = ERASER (size = 75);					
-									
-"default" = "red Pen";						
-"default"[SHIFT] = "blue Pen";					
-"default"[CONTROL] = "yellow Pen";				
-"default"[2] = "green Marker";					
-"default"[Button3] = "Eraser";					
+"red Pen" = PEN (size=5 color="red");
+"blue Pen" = "red Pen" (color="blue");
+"yellow Pen" = "red Pen" (color="yellow");
+"green Marker" = PEN (size=6 color="green" arrowsize=1 arrowposition="end");
+
+"Eraser" = ERASER (size = 75);
+
+"default" = "red Pen";
+"default"[SHIFT] = "blue Pen";
+"default"[CONTROL] = "yellow Pen";
+"default"[2] = "green Marker";
+"default"[Button3] = "Eraser";
 

--- a/src/drawing.h
+++ b/src/drawing.h
@@ -8,15 +8,25 @@
 
 #include "main.h"
 
+typedef struct
+{
+  gint x;
+  gint y;
+  gint width;
+} GromitStrokeCoordinate;
+
+
 void draw_line (GromitData *data, GdkDevice *dev, gint x1, gint y1, gint x2, gint y2);
 void draw_arrow (GromitData *data, GdkDevice *dev, gint x1, gint y1, gint width, gfloat direction);
-
+void draw_arrow_when_applicable(GdkDevice *device, GromitDeviceData *devdata, GromitData *data, GromitArrowPosition position);
 gboolean coord_list_get_arrow_param (GromitData *data,
-					    GdkDevice  *dev,
-					    gint        search_radius,
-					    gint       *ret_width,
-					    gfloat     *ret_direction);
+					    GdkDevice  					*dev,
+					    gint        				search_radius,
+							GromitArrowPosition arrowposition,
+					    gint       					*ret_width,
+					    gfloat     					*ret_direction);
 void coord_list_prepend (GromitData *data, GdkDevice* dev, gint x, gint y, gint width);
+void cleanup_context(GromitPaintContext *context);
 void coord_list_free (GromitData *data, GdkDevice* dev);
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Gromit -- a program for painting on the screen
  * Copyright (C) 2000 Simon Budig <Simon.Budig@unix-ag.org>
  *
@@ -66,16 +66,26 @@ typedef enum
   GROMIT_RECOLOR
 } GromitPaintType;
 
+typedef enum
+{
+  GROMIT_ARROW_AT_NONE = 0,
+  GROMIT_ARROW_AT_START = 1,
+  GROMIT_ARROW_AT_END = 2,
+  GROMIT_ARROW_AT_BOTH = GROMIT_ARROW_AT_START | GROMIT_ARROW_AT_END
+} GromitArrowPosition;
+
 typedef struct
 {
-  GromitPaintType type;
-  guint           width;
-  gfloat          arrowsize;
-  guint           minwidth;
-  guint           maxwidth;
-  GdkRGBA         *paint_color;
-  cairo_t         *paint_ctx;
-  gdouble         pressure;
+  GromitPaintType     type;
+  guint               width;
+  gfloat              arrowsize;
+  GromitArrowPosition arrowposition;
+  guint               minwidth;
+  guint               maxwidth;
+  GdkRGBA             *paint_color;
+  cairo_t             *paint_ctx;
+  gdouble             pressure;
+  gboolean            start_arrow_painted;
 } GromitPaintContext;
 
 typedef struct
@@ -119,7 +129,7 @@ typedef struct
 
   GromitPaintContext *default_pen;
   GromitPaintContext *default_eraser;
- 
+
   GHashTable  *tool_config;
 
   cairo_surface_t *backbuffer;
@@ -164,7 +174,7 @@ void redo_drawing (GromitData *data);
 void clear_screen (GromitData *data);
 
 GromitPaintContext *paint_context_new (GromitData *data, GromitPaintType type,
-				       GdkRGBA *fg_color, guint width, guint arrowsize,
+				       GdkRGBA *fg_color, guint width, guint arrowsize, GromitArrowPosition arrowposition,
                                        guint minwidth, guint maxwidth);
 void paint_context_free (GromitPaintContext *context);
 


### PR DESCRIPTION
Hello, I've just added this option to draw arrows at either different or both sides of the lines. 

![image](https://user-images.githubusercontent.com/4236481/136467366-16758384-9035-4614-8196-619d4abd6f40.png)
(all lines drawn from left to right)

The configuration is as simple as:

```
"red Marker end" = PEN (size=6 color="red" arrowsize=1 arrowposition="end");    
"red Marker start" = PEN (size=6 color="red" arrowsize=1 arrowposition="start");    
"red Marker both" = PEN (size=6 color="red" arrowsize=1 arrowposition="both");
```

I did it in a single commit because it was not a huge change, let me know whether it doesn't fit the contributing guidelines so I can split it up.

I was looking for a tool which mimics drawing features of [Microsoft ZoomIt](https://docs.microsoft.com/en-us/sysinternals/downloads/zoomit) and gromit seems to be the right tool for that, but it lacks some drawing features that users like me would miss when migrating from Windows environment.

Another feature I want to work on is #67, for the same reason.
