### PR TITLE
Added options for editing max undo-history depth

### DIFF
--- a/data/gromit-mpx.cfg
+++ b/data/gromit-mpx.cfg
@@ -19,3 +19,4 @@
 "default"[2] = "green Marker";					
 "default"[Button3] = "Eraser";					
 
+History = 4 

--- a/gromit-mpx.1
+++ b/gromit-mpx.1
@@ -1,5 +1,5 @@
 .\"                                      Hey, vim: ft=nroff
-.TH GROMIT-MPX 1 "November 3, 2018"
+.TH GROMIT-MPX 1 "January 23, 2022"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -85,6 +85,10 @@ will change the key used to undo/redo strokes. Under rare circumstances
 identifying the key with the keysym can fail. You can then use the keycode
 to specify the key uniquely. To determine the keycode for different keys you
 can use the \fBxev\fP(1) command.
+.TP
+.B \-H <value>, \-\-history\-steps <value>
+will change the available undo history depth (default = 4).
+Increasing it will also increase the ram usage.
 .TP
 .B \-V, \-\-version
 will show the Gromit-MPX version.

--- a/src/config.h
+++ b/src/config.h
@@ -48,6 +48,9 @@ int parse_args (int argc, char **argv, GromitData *data);
 #ifndef DEFAULT_OPACITY
 #define DEFAULT_OPACITY 0.75
 #endif
+#ifndef DEFAULT_HISTORY_STEPS
+#define DEFAULT_HISTORY_STEPS 4
+#endif
 
 void read_keyfile(GromitData *data);
 

--- a/src/main.h
+++ b/src/main.h
@@ -57,7 +57,6 @@
 #define GA_DATA       gdk_atom_intern ("Gromit/data", FALSE)
 #define GA_TOGGLEDATA gdk_atom_intern ("Gromit/toggledata", FALSE)
 
-#define GROMIT_MAX_UNDO 4
 
 typedef enum
 {
@@ -139,8 +138,9 @@ typedef struct
 
   gchar       *clientdata;
 
-  cairo_surface_t *undobuffer[GROMIT_MAX_UNDO];
+  cairo_surface_t **undobuffer;
   gint            undo_head, undo_depth, redo_depth;
+  gint            undo_steps;
 
   gboolean show_intro_on_startup;
 


### PR DESCRIPTION
When using the tool I noticed the default amount of undo steps we could make was really low for my needs. It was probably done for memory issues as increasing the max depth to 1000 filled my 16GB ram. Fyi at 2K resolution 100 steps take 1.4GB in my machine.

I added the ability for users to change that through either the .cfg file or the cli.

There is a repeating section of code now throughout the code:

```
data->undo_steps = (gint) scanner->value.v_float;
data->undobuffer = calloc(data->undo_steps, sizeof(cairo_surface_t*));

for (int i = 0; i < data->undo_steps; i++)
{
  cairo_surface_destroy(data->undobuffer[i]);
  data->undobuffer[i] = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, data->width, data->height);
}
``` 
maybe it should be put inside some function?
