### PR TITLE
Allow key modifiers in HOTKEY configuration setting

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -694,7 +694,7 @@ void setup_main_app (GromitData *data, int argc, char ** argv)
           // strip modifiers such as <Super> before looking up keycode
           gchar    *hot_keyval = data->hot_keyval;
           if (hot_keyval[0] == '<' && strrchr(hot_keyval, '>'))
-            hot_keyval = strchr(hot_keyval, '>') + 1;
+            hot_keyval = strrchr(hot_keyval, '>') + 1;
 
           keyval = gdk_keyval_from_name (hot_keyval);
 

--- a/src/main.c
+++ b/src/main.c
@@ -691,7 +691,12 @@ void setup_main_app (GromitData *data, int argc, char ** argv)
           strcasecmp (data->hot_keyval, "none") != 0)
         {
           keymap = gdk_keymap_get_for_display (data->display);
-          keyval = gdk_keyval_from_name (data->hot_keyval);
+          // strip modifiers such as <Super> before looking up keycode
+          gchar    *hot_keyval = data->hot_keyval;
+          if (hot_keyval[0] == '<' && strrchr(hot_keyval, '>'))
+            hot_keyval = strchr(hot_keyval, '>') + 1;
+
+          keyval = gdk_keyval_from_name (hot_keyval);
 
           if (!keyval || !gdk_keymap_get_entries_for_keyval (keymap, keyval,
                                                              &keys, &n_keys))


### PR DESCRIPTION
Currently, it is not possible to specify modifiers for the hotkey that toggles Gromit on.
Usually, this is ok: the code snoops for all modifiers, and then applies different actions (toggle, clear, etc.) based on the modifiers (such as CTRL, SHIFT, etc.)

However, if an input device (such as a Dell active pen) triggers keystrokes with modifiers, then omitting the modifier in the `.cfg` file will not be compatible with the required keybindings implemented in [6501486](https://github.com/bk138/gromit-mpx/commit/6501486df975205eb202f06b7b1da3883d65e5f9).

This PR strips the modifiers before trying to convert the symbolic keyval to a keycode.  However, the modifier is kept in the symbolic keyval so it can be added correctly when installing the keybindings.

Comments are welcome - is this the right way to do this?
