### PR TITLE
gromit-mpx: Forward-declare app_parse_args.

### DIFF
--- a/src/gromit-mpx.c
+++ b/src/gromit-mpx.c
@@ -696,7 +696,7 @@ void main_do_event (GdkEventAny *event,
 }
 
 
-
+int app_parse_args (int argc, char **argv, GromitData *data);
 
 
 void setup_main_app (GromitData *data, int argc, char ** argv)


### PR DESCRIPTION
This fixes the implicit-function-declaration warning and incompatibility with C99.
see e.g. https://bugs.gentoo.org/888149