### PR TITLE
! in comparison changed to !=

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -575,7 +575,7 @@ void on_device_removed (GdkDeviceManager *device_manager,
 {
   GromitData *data = (GromitData *) user_data;
     
-  if(!gdk_device_get_device_type(device) == GDK_DEVICE_TYPE_MASTER
+  if(gdk_device_get_device_type(device) != GDK_DEVICE_TYPE_MASTER
      || gdk_device_get_n_axes(device) < 2)
     return;
   
@@ -591,7 +591,7 @@ void on_device_added (GdkDeviceManager *device_manager,
 {
   GromitData *data = (GromitData *) user_data;
 
-  if(!gdk_device_get_device_type(device) == GDK_DEVICE_TYPE_MASTER
+  if(gdk_device_get_device_type(device) != GDK_DEVICE_TYPE_MASTER
      || gdk_device_get_n_axes(device) < 2)
     return;
 


### PR DESCRIPTION
This refers to https://github.com/bk138/gromit-mpx/issues/188

```
  if(!gdk_device_get_device_type(device) == GDK_DEVICE_TYPE_MASTER ...)
```
was a bit unfortunate since this evaluates to TRUE when gdk_device_get_device_type returns values > 0, since GDK_DEVICE_TYPE_MASTER is 0.

Changed to the clearer form:
```
  if (gdk_device_get_device_type(device) != GDK_DEVICE_TYPE_MASTER ...)
```