### PR TITLE
Implementation of additional tools to draw rectangles and straight lines and arrows

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -142,10 +142,10 @@ void on_monitors_changed ( GdkScreen *screen,
   parse_config(data); // also calls paint_context_new() :-(
 
 
-  data->default_pen = paint_context_new (data, GROMIT_PEN,
-					 data->red, 7, 0, 1, G_MAXUINT);
-  data->default_eraser = paint_context_new (data, GROMIT_ERASER,
-					    data->red, 75, 0, 1, G_MAXUINT);
+  data->default_pen = paint_context_new (data, GROMIT_PEN, data->red, 7,
+                                         0, GROMIT_ARROW_NONE, 1, G_MAXUINT);
+  data->default_eraser = paint_context_new (data, GROMIT_ERASER, data->red, 75,
+                                            0, GROMIT_ARROW_NONE, 1, G_MAXUINT);
 
   if(!data->composited) // set shape
     {
@@ -398,7 +398,18 @@ gboolean on_motion (GtkWidget *win,
           }
           if (type == GROMIT_LINE)
             {
+              GromitArrowType atype = devdata->cur_context->arrow_type;
 	      draw_line (data, ev->device, devdata->lastx, devdata->lasty, ev->x, ev->y);
+              if (atype != GROMIT_ARROW_NONE)
+                {
+                  gint width = devdata->cur_context->arrowsize * devdata->cur_context->width / 2;
+                  gfloat direction =
+                      atan2(ev->y - devdata->lasty, ev->x - devdata->lastx);
+                  if (atype & GROMIT_ARROW_END)
+                    draw_arrow(data, ev->device, ev->x, ev->y, width * 2, direction);
+                  if (atype & GROMIT_ARROW_START)
+                    draw_arrow(data, ev->device, devdata->lastx, devdata->lasty, width * 2, M_PI + direction);
+                }
             }
           else if (type == GROMIT_RECT)
             {
@@ -451,15 +462,27 @@ gboolean on_buttonrelease (GtkWidget *win,
 
   if (devdata->cur_context->arrowsize != 0)
     {
+      GromitArrowType atype = devdata->cur_context->arrow_type;
       if (type == GROMIT_LINE)
         {
           direction = atan2 (ev->y - devdata->lasty, ev->x - devdata->lastx);
-          draw_arrow(data, ev->device, ev->x, ev->y, width * 2, direction);
+          if (atype & GROMIT_ARROW_END)
+            draw_arrow(data, ev->device, ev->x, ev->y, width * 2, direction);
+          if (atype & GROMIT_ARROW_START)
+            draw_arrow(data, ev->device, devdata->lastx, devdata->lasty, width * 2, M_PI + direction);
         }
-      else if (coord_list_get_arrow_param (data, ev->device, width * 3,
-                                           &width, &direction))
+      else
         {
-          draw_arrow (data, ev->device, ev->x, ev->y, width, direction);
+          gint x0, y0;
+          if ((atype & GROMIT_ARROW_END) &&
+              coord_list_get_arrow_param (data, ev->device, width * 3,
+                                          GROMIT_ARROW_END, &x0, &y0, &width, &direction))
+            draw_arrow (data, ev->device, x0, y0, width, direction);
+          if ((atype & GROMIT_ARROW_START) &&
+              coord_list_get_arrow_param (data, ev->device, width * 3,
+                                          GROMIT_ARROW_START, &x0, &y0, &width, &direction)) {
+            draw_arrow (data, ev->device, x0, y0, width, direction);
+          }
         }
     }
 
@@ -591,7 +614,9 @@ void on_mainapp_selection_received (GtkWidget *widget,
 	      g_printerr ("Unable to parse color. "
 	      "Keeping default.\n");
 	    }
-	  GromitPaintContext* line_ctx = paint_context_new(data, GROMIT_PEN, fg_color, thickness, 0, thickness, thickness);
+	  GromitPaintContext* line_ctx =
+            paint_context_new(data, GROMIT_PEN, fg_color, thickness,
+                              0, GROMIT_ARROW_NONE, thickness, thickness);
 
 	  GdkRectangle rect;
 	  rect.x = MIN (startX,endX) - thickness / 2;

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -61,6 +61,8 @@ gboolean on_expose (GtkWidget *widget,
 }
 
 
+
+
 gboolean on_configure (GtkWidget *widget,
 		       GdkEventExpose *event,
 		       gpointer user_data)
@@ -72,6 +74,7 @@ gboolean on_configure (GtkWidget *widget,
 
   return TRUE;
 }
+
 
 
 void on_screen_changed(GtkWidget *widget,
@@ -135,12 +138,15 @@ void on_monitors_changed ( GdkScreen *screen,
     paint_context_free(value);
   g_hash_table_remove_all(data->tool_config);
 
+
   parse_config(data); // also calls paint_context_new() :-(
+
 
   data->default_pen = paint_context_new (data, GROMIT_PEN,
 					 data->red, 7, 0, 1, G_MAXUINT);
   data->default_eraser = paint_context_new (data, GROMIT_ERASER,
 					    data->red, 75, 0, 1, G_MAXUINT);
+
   if(!data->composited) // set shape
     {
       cairo_region_t* r = gdk_cairo_region_create_from_surface(data->backbuffer);
@@ -149,6 +155,7 @@ void on_monitors_changed ( GdkScreen *screen,
     }
 
   setup_input_devices(data);
+
 
   gtk_widget_show_all (data->win);
 }
@@ -266,6 +273,7 @@ gboolean on_buttonpress (GtkWidget *win,
   /* See GdkModifierType. Am I fixing a Gtk misbehaviour???  */
   ev->state |= 1 << (ev->button + 7);
 
+
   if (ev->state != devdata->state ||
       devdata->lastslave != gdk_event_get_source_device ((GdkEvent *) ev))
     select_tool (data, ev->device, gdk_event_get_source_device ((GdkEvent *) ev), ev->state);
@@ -363,6 +371,7 @@ gboolean on_motion (GtkWidget *win,
                 }
             }
         }
+
       devdata->motion_time = coords[nevents-1]->time;
       g_free (coords);
     }

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <math.h>
 #include "main.h"
 #include "input.h"
 #include "callbacks.h"
@@ -60,8 +61,6 @@ gboolean on_expose (GtkWidget *widget,
 }
 
 
-
-
 gboolean on_configure (GtkWidget *widget,
 		       GdkEventExpose *event,
 		       gpointer user_data)
@@ -73,7 +72,6 @@ gboolean on_configure (GtkWidget *widget,
 
   return TRUE;
 }
-
 
 
 void on_screen_changed(GtkWidget *widget,
@@ -122,7 +120,11 @@ void on_monitors_changed ( GdkScreen *screen,
   cairo_destroy (cr);
   cairo_surface_destroy(data->backbuffer);
   data->backbuffer = new_shape;
- 
+
+  // recreate temp_buffer
+  cairo_surface_destroy(data->temp_buffer);
+  data->temp_buffer = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, data->width, data->height);
+
   /*
      these depend on the shape surface
   */
@@ -133,15 +135,12 @@ void on_monitors_changed ( GdkScreen *screen,
     paint_context_free(value);
   g_hash_table_remove_all(data->tool_config);
 
-
   parse_config(data); // also calls paint_context_new() :-(
-
 
   data->default_pen = paint_context_new (data, GROMIT_PEN,
 					 data->red, 7, 0, 1, G_MAXUINT);
   data->default_eraser = paint_context_new (data, GROMIT_ERASER,
 					    data->red, 75, 0, 1, G_MAXUINT);
-
   if(!data->composited) // set shape
     {
       cairo_region_t* r = gdk_cairo_region_create_from_surface(data->backbuffer);
@@ -150,7 +149,6 @@ void on_monitors_changed ( GdkScreen *screen,
     }
 
   setup_input_devices(data);
-
 
   gtk_widget_show_all (data->win);
 }
@@ -268,10 +266,17 @@ gboolean on_buttonpress (GtkWidget *win,
   /* See GdkModifierType. Am I fixing a Gtk misbehaviour???  */
   ev->state |= 1 << (ev->button + 7);
 
-
   if (ev->state != devdata->state ||
       devdata->lastslave != gdk_event_get_source_device ((GdkEvent *) ev))
     select_tool (data, ev->device, gdk_event_get_source_device ((GdkEvent *) ev), ev->state);
+
+  GromitPaintType type = devdata->cur_context->type;
+
+  // store original state to have dynamic update of line and rect
+  if (type == GROMIT_LINE || type == GROMIT_RECT)
+    {
+      copy_surface(data->temp_buffer, data->backbuffer);
+    }
 
   devdata->lastx = ev->x;
   devdata->lasty = ev->y;
@@ -319,41 +324,45 @@ gboolean on_motion (GtkWidget *win,
       devdata->lastslave != gdk_event_get_source_device ((GdkEvent *) ev))
     select_tool (data, ev->device, gdk_event_get_source_device ((GdkEvent *) ev), ev->state);
 
+  GromitPaintType type = devdata->cur_context->type;
+
   gdk_device_get_history (ev->device, ev->window,
 			  devdata->motion_time, ev->time,
 			  &coords, &nevents);
 
   if(!data->xinerama && nevents > 0)
     {
-      for (i=0; i < nevents; i++)
+      if (type != GROMIT_LINE && type != GROMIT_RECT)
         {
-          gdouble x, y;
-
-          gdk_device_get_axis (ev->device, coords[i]->axes,
-                               GDK_AXIS_PRESSURE, &pressure);
-          if (pressure > 0)
+          for (i=0; i < nevents; i++)
             {
-	      data->maxwidth = (CLAMP (pressure + line_thickener, 0, 1) *
-				(double) (devdata->cur_context->width -
-					  devdata->cur_context->minwidth) +
-				devdata->cur_context->minwidth);
+              gdouble x, y;
 
-	      if(data->maxwidth > devdata->cur_context->maxwidth)
-		data->maxwidth = devdata->cur_context->maxwidth;
+              gdk_device_get_axis (ev->device, coords[i]->axes,
+                                   GDK_AXIS_PRESSURE, &pressure);
+              if (pressure > 0)
+                {
+                  data->maxwidth = (CLAMP (pressure + line_thickener, 0, 1) *
+                                    (double) (devdata->cur_context->width -
+                                              devdata->cur_context->minwidth) +
+                                    devdata->cur_context->minwidth);
 
-              gdk_device_get_axis(ev->device, coords[i]->axes,
-                                  GDK_AXIS_X, &x);
-              gdk_device_get_axis(ev->device, coords[i]->axes,
-                                  GDK_AXIS_Y, &y);
+                  if(data->maxwidth > devdata->cur_context->maxwidth)
+                    data->maxwidth = devdata->cur_context->maxwidth;
 
-	      draw_line (data, ev->device, devdata->lastx, devdata->lasty, x, y);
+                  gdk_device_get_axis(ev->device, coords[i]->axes,
+                                      GDK_AXIS_X, &x);
+                  gdk_device_get_axis(ev->device, coords[i]->axes,
+                                      GDK_AXIS_Y, &y);
 
-              coord_list_prepend (data, ev->device, x, y, data->maxwidth);
-              devdata->lastx = x;
-              devdata->lasty = y;
+                  draw_line (data, ev->device, devdata->lastx, devdata->lasty, x, y);
+
+                  coord_list_prepend (data, ev->device, x, y, data->maxwidth);
+                  devdata->lastx = x;
+                  devdata->lasty = y;
+                }
             }
         }
-
       devdata->motion_time = coords[nevents-1]->time;
       g_free (coords);
     }
@@ -373,13 +382,35 @@ gboolean on_motion (GtkWidget *win,
 
       if(devdata->motion_time > 0)
 	{
-	  draw_line (data, ev->device, devdata->lastx, devdata->lasty, ev->x, ev->y);
-	  coord_list_prepend (data, ev->device, ev->x, ev->y, data->maxwidth);
+          if (type == GROMIT_LINE || type == GROMIT_RECT) {
+            copy_surface(data->backbuffer, data->temp_buffer);
+            GdkRectangle rect = {0, 0, data->width, data->height};
+            gdk_window_invalidate_rect(gtk_widget_get_window(data->win), &rect, 0);
+          }
+          if (type == GROMIT_LINE)
+            {
+	      draw_line (data, ev->device, devdata->lastx, devdata->lasty, ev->x, ev->y);
+            }
+          else if (type == GROMIT_RECT)
+            {
+              draw_line (data, ev->device, devdata->lastx, devdata->lasty, ev->x, devdata->lasty);
+              draw_line (data, ev->device, ev->x, devdata->lasty, ev->x, ev->y);
+              draw_line (data, ev->device, ev->x, ev->y, devdata->lastx, ev->y);
+              draw_line (data, ev->device, devdata->lastx, ev->y, devdata->lastx, devdata->lasty);
+            }
+          else
+            {
+              draw_line (data, ev->device, devdata->lastx, devdata->lasty, ev->x, ev->y);
+	      coord_list_prepend (data, ev->device, ev->x, ev->y, data->maxwidth);
+            }
 	}
     }
 
-  devdata->lastx = ev->x;
-  devdata->lasty = ev->y;
+  if (type != GROMIT_LINE && type != GROMIT_RECT)
+    {
+      devdata->lastx = ev->x;
+      devdata->lasty = ev->y;
+    }
   devdata->motion_time = ev->time;
 
   return TRUE;
@@ -406,11 +437,22 @@ gboolean on_buttonrelease (GtkWidget *win,
 
   if (!devdata->is_grabbed)
     return FALSE;
-  
-  if (devdata->cur_context->arrowsize != 0 &&
-      coord_list_get_arrow_param (data, ev->device, width * 3,
-				  &width, &direction))
-    draw_arrow (data, ev->device, ev->x, ev->y, width, direction);
+
+  GromitPaintType type = devdata->cur_context->type;
+
+  if (devdata->cur_context->arrowsize != 0)
+    {
+      if (type == GROMIT_LINE)
+        {
+          direction = atan2 (ev->y - devdata->lasty, ev->x - devdata->lastx);
+          draw_arrow(data, ev->device, ev->x, ev->y, width * 2, direction);
+        }
+      else if (coord_list_get_arrow_param (data, ev->device, width * 3,
+                                           &width, &direction))
+        {
+          draw_arrow (data, ev->device, ev->x, ev->y, width, direction);
+        }
+    }
 
   coord_list_free (data, ev->device);
 

--- a/src/config.c
+++ b/src/config.c
@@ -168,6 +168,8 @@ gboolean parse_config (GromitData *data)
   scanner->config->int_2_float = 1;
 
   g_scanner_scope_add_symbol (scanner, 0, "PEN",    (gpointer) GROMIT_PEN);
+  g_scanner_scope_add_symbol (scanner, 0, "LINE",   (gpointer) GROMIT_LINE);
+  g_scanner_scope_add_symbol (scanner, 0, "RECT",   (gpointer) GROMIT_RECT);
   g_scanner_scope_add_symbol (scanner, 0, "ERASER", (gpointer) GROMIT_ERASER);
   g_scanner_scope_add_symbol (scanner, 0, "RECOLOR",(gpointer) GROMIT_RECOLOR);
   g_scanner_scope_add_symbol (scanner, 0, "HOTKEY",            HOTKEY_SYMBOL_VALUE);

--- a/src/drawing.c
+++ b/src/drawing.c
@@ -136,6 +136,7 @@ void coord_list_prepend (GromitData *data,
 void coord_list_free (GromitData *data, 
 		      GdkDevice* dev)
 {
+
   /* get the data for this device */
   GromitDeviceData *devdata = g_hash_table_lookup(data->devdatatable, dev);
 

--- a/src/drawing.c
+++ b/src/drawing.c
@@ -136,7 +136,6 @@ void coord_list_prepend (GromitData *data,
 void coord_list_free (GromitData *data, 
 		      GdkDevice* dev)
 {
-
   /* get the data for this device */
   GromitDeviceData *devdata = g_hash_table_lookup(data->devdatatable, dev);
 

--- a/src/drawing.h
+++ b/src/drawing.h
@@ -12,10 +12,13 @@ void draw_line (GromitData *data, GdkDevice *dev, gint x1, gint y1, gint x2, gin
 void draw_arrow (GromitData *data, GdkDevice *dev, gint x1, gint y1, gint width, gfloat direction);
 
 gboolean coord_list_get_arrow_param (GromitData *data,
-					    GdkDevice  *dev,
-					    gint        search_radius,
-					    gint       *ret_width,
-					    gfloat     *ret_direction);
+				     GdkDevice  *dev,
+				     gint        search_radius,
+                                     GromitArrowType arrow_end,
+                                     gint       *x0,
+                                     gint       *y0,
+				     gint       *ret_width,
+				     gfloat     *ret_direction);
 void coord_list_prepend (GromitData *data, GdkDevice* dev, gint x, gint y, gint width);
 void coord_list_free (GromitData *data, GdkDevice* dev);
 

--- a/src/main.c
+++ b/src/main.c
@@ -84,6 +84,10 @@ void paint_context_print (gchar *name,
   {
     case GROMIT_PEN:
       g_printerr ("Pen,     "); break;
+    case GROMIT_LINE:
+      g_printerr ("Line,    "); break;
+    case GROMIT_RECT:
+      g_printerr ("Rect,    "); break;
     case GROMIT_ERASER:
       g_printerr ("Eraser,  "); break;
     case GROMIT_RECOLOR:
@@ -254,8 +258,7 @@ void select_tool (GromitData *data,
       name = (guchar*) g_strndup (gdk_device_get_name(device), len + 3);
       default_len = strlen(DEFAULT_DEVICE_NAME);
       default_name = (guchar*) g_strndup (DEFAULT_DEVICE_NAME, default_len + 3);
-      
-      
+
       /* Extract Button/Modifiers from state (see GdkModifierType) */
       req_buttons = (state >> 8) & 31;
 
@@ -358,13 +361,11 @@ void select_tool (GromitData *data,
   else
     cursor = data->paint_cursor;
 
-
   if(data->debug)
-    g_printerr("DEBUG: select_tool setting cursor %p\n",cursor);
+    g_printerr("DEBUG: select_tool setting cursor %p\n", cursor);
 
-
-  //FIXME!  Should be:
-  //gdk_window_set_cursor(gtk_widget_get_window(data->win), cursor);
+  // FIXME!  Should be:
+  // gdk_window_set_cursor(gtk_widget_get_window(data->win), cursor);
   // doesn't work during a grab?
   gdk_device_grab(device,
   		  gtk_widget_get_window(data->win),
@@ -592,8 +593,10 @@ void setup_main_app (GromitData *data, int argc, char ** argv)
       cairo_surface_destroy(data->undobuffer[i]);
       data->undobuffer[i] = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, data->width, data->height);
     }
-  
 
+  // original state for LINE and RECT tool
+  cairo_surface_destroy(data->temp_buffer);
+  data->temp_buffer = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, data->width, data->height);
 
   /* EVENTS */
   gtk_widget_add_events (data->win, GROMIT_WINDOW_EVENTS);
@@ -613,15 +616,15 @@ void setup_main_app (GromitData *data, int argc, char ** argv)
                     G_CALLBACK (on_device_removed), data);
   g_signal_connect (data->win, "motion_notify_event",
 		    G_CALLBACK (on_motion), data);
-  g_signal_connect (data->win, "button_press_event", 
+  g_signal_connect (data->win, "button_press_event",
 		    G_CALLBACK (on_buttonpress), data);
   g_signal_connect (data->win, "button_release_event",
 		    G_CALLBACK (on_buttonrelease), data);
   /* disconnect previously defined selection handlers */
-  g_signal_handlers_disconnect_by_func (data->win, 
+  g_signal_handlers_disconnect_by_func (data->win,
 					G_CALLBACK (on_clientapp_selection_get),
 					data);
-  g_signal_handlers_disconnect_by_func (data->win, 
+  g_signal_handlers_disconnect_by_func (data->win,
 					G_CALLBACK (on_clientapp_selection_received),
 					data);
   /* and re-connect them to mainapp functions */

--- a/src/main.c
+++ b/src/main.c
@@ -40,6 +40,7 @@ GromitPaintContext *paint_context_new (GromitData *data,
 				       GdkRGBA *paint_color, 
 				       guint width,
 				       guint arrowsize,
+                                       GromitArrowType arrowtype,
 				       guint minwidth,
 				       guint maxwidth)
 {
@@ -50,11 +51,12 @@ GromitPaintContext *paint_context_new (GromitData *data,
   context->type = type;
   context->width = width;
   context->arrowsize = arrowsize;
+  context->arrow_type = arrowtype;
   context->minwidth = minwidth;
   context->maxwidth = maxwidth;
   context->paint_color = paint_color;
 
-  
+
   context->paint_ctx = cairo_create (data->backbuffer);
 
   gdk_cairo_set_source_rgba(context->paint_ctx, paint_color);
@@ -100,6 +102,22 @@ void paint_context_print (gchar *name,
   g_printerr ("minwidth: %u, ", context->minwidth);
   g_printerr ("maxwidth: %u, ", context->maxwidth);
   g_printerr ("arrowsize: %.2f, ", context->arrowsize);
+  if (context->arrowsize > 0)
+    {
+      switch (context->arrow_type) {
+      case GROMIT_ARROW_START:
+        g_printerr(" arrowtype: <- , ");
+        break;
+      case GROMIT_ARROW_END:
+        g_printerr(" arrowtype:  ->, ");
+        break;
+      case GROMIT_ARROW_DOUBLE:
+        g_printerr(" arrowtype: <->, ");
+        break;
+      case GROMIT_ARROW_NONE:
+        break;
+      }
+    }
   g_printerr ("color: %s\n", gdk_rgba_to_string(context->paint_color));
 }
 
@@ -758,12 +776,12 @@ void setup_main_app (GromitData *data, int argc, char ** argv)
  
   data->modified = 0;
 
-  data->default_pen = paint_context_new (data, GROMIT_PEN,
-					 data->red, 7, 0, 1, G_MAXUINT);
-  data->default_eraser = paint_context_new (data, GROMIT_ERASER,
-					    data->red, 75, 0, 1, G_MAXUINT);
-
-  
+  data->default_pen =
+    paint_context_new (data, GROMIT_PEN, data->red, 7,
+                       0, GROMIT_ARROW_NONE, 1, G_MAXUINT);
+  data->default_eraser =
+    paint_context_new (data, GROMIT_ERASER, data->red, 75,
+                       0, GROMIT_ARROW_NONE, 1, G_MAXUINT);
 
   gdk_event_handler_set ((GdkEventFunc) main_do_event, data, NULL);
   gtk_key_snooper_install (snoop_key_press, data);

--- a/src/main.c
+++ b/src/main.c
@@ -258,7 +258,8 @@ void select_tool (GromitData *data,
       name = (guchar*) g_strndup (gdk_device_get_name(device), len + 3);
       default_len = strlen(DEFAULT_DEVICE_NAME);
       default_name = (guchar*) g_strndup (DEFAULT_DEVICE_NAME, default_len + 3);
-
+      
+      
       /* Extract Button/Modifiers from state (see GdkModifierType) */
       req_buttons = (state >> 8) & 31;
 
@@ -361,11 +362,13 @@ void select_tool (GromitData *data,
   else
     cursor = data->paint_cursor;
 
-  if(data->debug)
-    g_printerr("DEBUG: select_tool setting cursor %p\n", cursor);
 
-  // FIXME!  Should be:
-  // gdk_window_set_cursor(gtk_widget_get_window(data->win), cursor);
+  if(data->debug)
+    g_printerr("DEBUG: select_tool setting cursor %p\n",cursor);
+
+
+  //FIXME!  Should be:
+  //gdk_window_set_cursor(gtk_widget_get_window(data->win), cursor);
   // doesn't work during a grab?
   gdk_device_grab(device,
   		  gtk_widget_get_window(data->win),
@@ -616,15 +619,15 @@ void setup_main_app (GromitData *data, int argc, char ** argv)
                     G_CALLBACK (on_device_removed), data);
   g_signal_connect (data->win, "motion_notify_event",
 		    G_CALLBACK (on_motion), data);
-  g_signal_connect (data->win, "button_press_event",
+  g_signal_connect (data->win, "button_press_event", 
 		    G_CALLBACK (on_buttonpress), data);
   g_signal_connect (data->win, "button_release_event",
 		    G_CALLBACK (on_buttonrelease), data);
   /* disconnect previously defined selection handlers */
-  g_signal_handlers_disconnect_by_func (data->win,
+  g_signal_handlers_disconnect_by_func (data->win, 
 					G_CALLBACK (on_clientapp_selection_get),
 					data);
-  g_signal_handlers_disconnect_by_func (data->win,
+  g_signal_handlers_disconnect_by_func (data->win, 
 					G_CALLBACK (on_clientapp_selection_received),
 					data);
   /* and re-connect them to mainapp functions */

--- a/src/main.h
+++ b/src/main.h
@@ -64,6 +64,8 @@
 typedef enum
 {
   GROMIT_PEN,
+  GROMIT_LINE,
+  GROMIT_RECT,
   GROMIT_ERASER,
   GROMIT_RECOLOR
 } GromitPaintType;
@@ -94,7 +96,6 @@ typedef struct
   gboolean     was_grabbed;
   GdkDevice*   lastslave;
 } GromitDeviceData;
-
 
 typedef struct
 {
@@ -143,6 +144,8 @@ typedef struct
 
   cairo_surface_t *undobuffer[GROMIT_MAX_UNDO];
   gint            undo_head, undo_depth, redo_depth;
+
+  cairo_surface_t *temp_buffer;
 
   gboolean show_intro_on_startup;
 

--- a/src/main.h
+++ b/src/main.h
@@ -70,11 +70,20 @@ typedef enum
   GROMIT_RECOLOR
 } GromitPaintType;
 
+typedef enum
+{
+  GROMIT_ARROW_NONE = 0,
+  GROMIT_ARROW_START = 1,
+  GROMIT_ARROW_END = 2,
+  GROMIT_ARROW_DOUBLE = 3
+} GromitArrowType;
+
 typedef struct
 {
   GromitPaintType type;
   guint           width;
   gfloat          arrowsize;
+  GromitArrowType arrow_type;
   guint           minwidth;
   guint           maxwidth;
   GdkRGBA         *paint_color;
@@ -170,7 +179,8 @@ void redo_drawing (GromitData *data);
 void clear_screen (GromitData *data);
 
 GromitPaintContext *paint_context_new (GromitData *data, GromitPaintType type,
-				       GdkRGBA *fg_color, guint width, guint arrowsize,
+				       GdkRGBA *fg_color, guint width,
+                                       guint arrowsize, GromitArrowType arrowtype,
                                        guint minwidth, guint maxwidth);
 void paint_context_free (GromitPaintContext *context);
 

--- a/src/main.h
+++ b/src/main.h
@@ -97,6 +97,7 @@ typedef struct
   GdkDevice*   lastslave;
 } GromitDeviceData;
 
+
 typedef struct
 {
   GtkWidget   *win;


### PR DESCRIPTION
PR to implement the additional `GromitPaintType`s LINE and RECT. In contrast to PEN, LINE draws a straight line, possibly with an arrow head. RECT draws a rectangle.

Also, there now is an option for different arrow types; these can be "->" (the default), "<-", and "<->".

The syntax to specify LINE, RECT, and arrowtype is as follows:

```
"red Pen" = PEN (size=5 color="#993333" arrowsize=2 arrowtype="->");
"yellow rect" = RECT (color="yellow" size=5);
"blue line" = LINE (color="cyan" size=5 arrowsize=2);
``` 

The result is as shown as shown here:
![gromit_LINE_RECT](https://github.com/bk138/gromit-mpx/assets/9673983/481a3418-9995-443d-abe1-9ec997324589)
