### PR TITLE
Support for a-z keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ Makefile.in
 /flatpak/.flatpak-builder/
 /flatpak/build-dir/
 /.cache/
+/.vscode/

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -273,7 +273,7 @@ gboolean on_buttonpress (GtkWidget *win,
   // add new buttons to GromitState
   GromitState newState = data->state;
   newState.buttons |= (ev->button <= 10) ? 1 << (ev->button - 1) : 0;
-  newState.modifiers = ev->state & 255;
+  newState.modifiers = ev->state & 0xF;
 
 
   if (!compare_state(data->state, newState) ||
@@ -329,9 +329,9 @@ gboolean on_motion (GtkWidget *win,
 
   // GdkEventMotion->state has only buttons 1-5, keep 6-10
   GromitState newState = data->state;
-  newState.buttons &= 992; // remove old 1-5, keep 6-10
-  newState.buttons |= (ev->state >> 8) & 1023; // update new 1-5
-  newState.modifiers = ev->state & 255;
+  newState.buttons &= 0x3E0; // remove old 1-5, keep 6-10
+  newState.buttons |= (ev->state >> 8) & 0x1F; // update new 1-5
+  newState.modifiers = ev->state & 0xF;
 
   // return if there is no button pressed
   if(!newState.buttons)
@@ -470,7 +470,7 @@ gboolean on_buttonrelease (GtkWidget *win,
   // remove released button bit from GromitState
   guint button = 1 << (ev->button - 1);
   data->state.buttons &= ~button;
-  data->state.modifiers = ev->state & 255;
+  data->state.modifiers = ev->state & 0xF;
 
   if (!devdata->is_grabbed)
     return FALSE;

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -271,12 +271,12 @@ gboolean on_buttonpress (GtkWidget *win,
   }
 
   // add new buttons to GromitState
-  GromitState newState = devdata->state;
+  GromitState newState = data->state;
   newState.buttons |= (ev->button <= 10) ? 1 << (ev->button - 1) : 0;
   newState.modifiers = ev->state & 255;
 
 
-  if (!compare_state(devdata->state, newState) ||
+  if (!compare_state(data->state, newState) ||
       devdata->lastslave != gdk_event_get_source_device ((GdkEvent *) ev))
     select_tool (data, ev->device, gdk_event_get_source_device ((GdkEvent *) ev), newState);
 
@@ -328,7 +328,7 @@ gboolean on_motion (GtkWidget *win,
     return FALSE;
 
   // GdkEventMotion->state has only buttons 1-5, keep 6-10
-  GromitState newState = devdata->state;
+  GromitState newState = data->state;
   newState.buttons &= 992; // remove old 1-5, keep 6-10
   newState.buttons |= (ev->state >> 8) & 1023; // update new 1-5
   newState.modifiers = ev->state & 255;
@@ -340,7 +340,7 @@ gboolean on_motion (GtkWidget *win,
   if(data->debug)
       g_printerr("DEBUG: Device '%s': motion to (x,y)=(%.2f : %.2f)\n", gdk_device_get_name(ev->device), ev->x, ev->y);
 
-  if(!compare_state(devdata->state, newState) ||
+  if(!compare_state(data->state, newState) ||
       devdata->lastslave != gdk_event_get_source_device ((GdkEvent *) ev))
     select_tool (data, ev->device, gdk_event_get_source_device ((GdkEvent *) ev), newState);
 
@@ -469,8 +469,8 @@ gboolean on_buttonrelease (GtkWidget *win,
 
   // remove released button bit from GromitState
   guint button = 1 << (ev->button - 1);
-  devdata->state.buttons &= ~button;
-  devdata->state.modifiers = ev->state & 255;
+  data->state.buttons &= ~button;
+  data->state.modifiers = ev->state & 255;
 
   if (!devdata->is_grabbed)
     return FALSE;

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -508,6 +508,53 @@ gboolean on_buttonrelease (GtkWidget *win,
   return TRUE;
 }
 
+gboolean on_keypress(GtkWidget *win, GdkEventKey *ev, gpointer user_data)
+{
+  GromitData *data = (GromitData *)user_data;
+
+  guint32 keyunicode = gdk_keyval_to_unicode(ev->keyval);
+  gchar *keyname = gdk_keyval_name(ev->keyval);
+  GdkDevice *dev = gdk_event_get_device((GdkEvent *)ev);
+
+  if (data->debug)
+    g_printerr("DEBUG: Received key %s %d press from device '%s'\n", keyname, keyunicode, gdk_device_get_name(dev));
+
+  // add key to GromitState
+  if (keyunicode >= GDK_KEY_a && keyunicode <= GDK_KEY_z)
+  {
+    data->state.keys |= 1 << (keyunicode - GDK_KEY_a);
+    return TRUE;
+  }
+  if (keyunicode >= GDK_KEY_A && keyunicode <= GDK_KEY_Z)
+  {
+    data->state.keys |= 1 << (keyunicode - GDK_KEY_A);
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+gboolean on_keyrelease(GtkWidget *win, GdkEventKey *ev, gpointer user_data)
+{
+  GromitData *data = (GromitData *)user_data;
+
+  guint32 keyunicode = gdk_keyval_to_unicode(ev->keyval);
+
+  // remove key from GromitState
+  if (keyunicode >= GDK_KEY_a && keyunicode <= GDK_KEY_z)
+  {
+    data->state.keys &= ~(1 << (keyunicode - GDK_KEY_a));
+    return TRUE;
+  }
+  if (keyunicode >= GDK_KEY_A && keyunicode <= GDK_KEY_Z)
+  {
+    data->state.keys &= ~(1 << (keyunicode - GDK_KEY_A));
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
 /* Remote control */
 void on_mainapp_selection_get (GtkWidget          *widget,
 			       GtkSelectionData   *selection_data,

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -65,6 +65,9 @@ gboolean on_motion (GtkWidget *win, GdkEventMotion *ev, gpointer user_data);
 
 gboolean on_buttonrelease (GtkWidget *win, GdkEventButton *ev, gpointer user_data);
 
+gboolean on_keypress(GtkWidget *win, GdkEventKey *ev, gpointer user_data);
+gboolean on_keyrelease(GtkWidget *win, GdkEventKey *ev, gpointer user_data);
+
 void on_mainapp_selection_get (GtkWidget          *widget,
 			       GtkSelectionData   *selection_data,
 			       guint               info,

--- a/src/config.c
+++ b/src/config.c
@@ -36,8 +36,8 @@
 
 #define KEYFILE_FLAGS G_KEY_FILE_KEEP_COMMENTS|G_KEY_FILE_KEEP_TRANSLATIONS
 
-static gpointer HOTKEY_SYMBOL_VALUE  = (gpointer) 3;
-static gpointer UNDOKEY_SYMBOL_VALUE = (gpointer) 4;
+static gpointer HOTKEY_SYMBOL_VALUE  = (gpointer) 5;
+static gpointer UNDOKEY_SYMBOL_VALUE = (gpointer) 6;
 
 /*
  * Functions for parsing the Configuration-file
@@ -49,6 +49,7 @@ static gboolean parse_name (GScanner *scanner, GromitLookupKey *key)
 
   guint buttons = 0;
   guint modifier = 0;
+  gulong keys = 0;
   guint len = 0;
 
   token = g_scanner_cur_token(scanner);
@@ -73,7 +74,7 @@ static gboolean parse_name (GScanner *scanner, GromitLookupKey *key)
     {
       g_scanner_set_scope (scanner, 1);
       scanner->config->int_2_float = 0;
-      modifier = buttons = 0;
+      modifier = buttons = keys = 0;
       while ((token = g_scanner_get_next_token (scanner))
              != G_TOKEN_RIGHT_BRACE)
         {
@@ -91,6 +92,11 @@ static gboolean parse_name (GScanner *scanner, GromitLookupKey *key)
               else
                 g_printerr ("Only Buttons 1-10 are supported!\n");
             }
+          // lower case and upper case write the same bit
+          else if (token >= GDK_KEY_a && token <= GDK_KEY_z)
+            keys |= 1 << (token - GDK_KEY_a);
+          else if (token >= GDK_KEY_A && token <= GDK_KEY_Z)
+            keys |= 1 << (token - GDK_KEY_A);
           else
             {
               g_printerr ("skipped token\n");
@@ -103,6 +109,7 @@ static gboolean parse_name (GScanner *scanner, GromitLookupKey *key)
 
   key->state.buttons = buttons;
   key->state.modifiers = modifier;
+  key->state.keys = keys;
 
   return 1;
 }

--- a/src/input.c
+++ b/src/input.c
@@ -266,72 +266,26 @@ void setup_input_devices (GromitData *data)
  
 	      if(kbd_dev_id != -1)
 		  {
-		      XIEventMask mask;
 		      unsigned char bits[4] = {0,0,0,0};
-		      mask.mask = bits;
-		      mask.mask_len = sizeof(bits);
-	      
 		      XISetMask(bits, XI_KeyPress);
 		      XISetMask(bits, XI_KeyRelease);
 	      
+		      XIEventMask mask;
+		      mask.mask = bits;
+		      mask.mask_len = sizeof(bits);
+	      
 		      XIGrabModifiers modifiers[] = {{XIAnyModifier, 0}};
-		      int nmods = 1;
 	      
 		      gdk_x11_display_error_trap_push(data->display);
 	      
 		      if (data->hot_keycode) {
-			  if(data->debug)
-			      g_printerr("DEBUG: Grabbing hot key '%s' from keyboard '%d' .\n", data->hot_keyval, kbd_dev_id);
-
-			  if(XIGrabKeycode(GDK_DISPLAY_XDISPLAY(data->display),
-					   kbd_dev_id,
-					   data->hot_keycode,
-					   GDK_WINDOW_XID(data->root),
-					   GrabModeAsync,
-					   GrabModeAsync,
-					   True,
-					   &mask,
-					   nmods,
-					   modifiers) != 0) {
-			      g_printerr("ERROR: Grabbing hotkey from keyboard device %d failed.\n", kbd_dev_id);
-			      GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(data->win),
-									 GTK_DIALOG_DESTROY_WITH_PARENT,
-									 GTK_MESSAGE_ERROR,
-									  GTK_BUTTONS_CLOSE,
-									 "Grabbing hotkey %s from keyboard %d failed. The drawing hotkey function will not work unless configured to use another key.",
-									 data->hot_keyval,
-									 kbd_dev_id);
-			      gtk_dialog_run (GTK_DIALOG (dialog));
-			      gtk_widget_destroy (dialog);
-
-			  }
+            grab_key(data, kbd_dev_id, data->hot_keyval,
+                        sizeof(modifiers) / sizeof(modifiers[0]), modifiers, &mask);
 		      }
 
 		      if (data->undo_keycode) {
-			  if(data->debug)
-			      g_printerr("DEBUG: Grabbing undo key '%s' from keyboard '%d' .\n", data->undo_keyval, kbd_dev_id);
-
-			  if(XIGrabKeycode(GDK_DISPLAY_XDISPLAY(data->display),
-					   kbd_dev_id,
-					   data->undo_keycode,
-					   GDK_WINDOW_XID(data->root),
-					   GrabModeAsync,
-					   GrabModeAsync,
-					   True,
-					   &mask,
-					   nmods,
-					   modifiers) != 0) {
-			      g_printerr("ERROR: Grabbing undo key from keyboard device %d failed.\n", kbd_dev_id);
-			      GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(data->win),
-									 GTK_DIALOG_DESTROY_WITH_PARENT,
-									 GTK_MESSAGE_ERROR,
-									  GTK_BUTTONS_CLOSE,
-									 "Grabbing undo key %s from keyboard %d failed. The undo hotkey function will not work unless configured to use another key.",
-									 data->undo_keyval,
-									 kbd_dev_id);
-			      gtk_dialog_run (GTK_DIALOG (dialog));
-			      gtk_widget_destroy (dialog);
-			  }
+            grab_key(data, kbd_dev_id, data->undo_keyval,
+                         sizeof(modifiers) / sizeof(modifiers[0]), modifiers, &mask);
 		      }
 
 		      XSync(GDK_DISPLAY_XDISPLAY(data->display), False);
@@ -625,4 +579,66 @@ gint snoop_key_press(GtkWidget   *grab_widget,
       return TRUE;
     }
   return FALSE;
+}
+
+guint grab_key(GromitData *data, gint device_id, const char *key, int num_modifiers, gpointer key_modifiers, gpointer mask)
+{
+  if (data->debug)
+    g_printerr("DEBUG: Grabbing key '%s' from keyboard '%d' .\n", key, device_id);
+
+  int result = XIGrabKeycode(GDK_DISPLAY_XDISPLAY(data->display),
+                             device_id,
+                             find_keycode(data->display, key),
+                             GDK_WINDOW_XID(data->root),
+                             GrabModeAsync,
+                             GrabModeAsync,
+                             True,
+                             (XIEventMask *)mask,
+                             num_modifiers,
+                             (XIGrabModifiers *)key_modifiers);
+
+  if (result != 0)
+  {
+    g_printerr("ERROR: Grabbing key %s from keyboard device %d failed.\n", key, device_id);
+    GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(data->win),
+                                               GTK_DIALOG_DESTROY_WITH_PARENT,
+                                               GTK_MESSAGE_ERROR,
+                                               GTK_BUTTONS_CLOSE,
+                                               "Grabbing key %s from keyboard %d failed. The key function will not work unless configured to use another key.",
+                                               key,
+                                               device_id);
+    gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+  }
+
+  return result;
+}
+
+guint ungrab_key(GromitData *data, gint device_id, const char *key, int num_modifiers, gpointer key_modifiers)
+{
+  if (data->debug)
+    g_printerr("DEBUG: Ungrabbing key '%s' from keyboard '%d' .\n", key, device_id);
+
+  int result = XIUngrabKeycode(GDK_DISPLAY_XDISPLAY(data->display),
+                               device_id,
+                               find_keycode(data->display, key),
+                               GDK_WINDOW_XID(data->root),
+                               num_modifiers,
+                               (XIGrabModifiers *)key_modifiers);
+
+  if (result != 0)
+  {
+    g_printerr("ERROR: Unrabbing key %s from keyboard device %d failed.\n", key, device_id);
+    GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(data->win),
+                                               GTK_DIALOG_DESTROY_WITH_PARENT,
+                                               GTK_MESSAGE_ERROR,
+                                               GTK_BUTTONS_CLOSE,
+                                               "Unrabbing key %s from keyboard %d failed. The key function will not work unless configured to use another key.",
+                                               key,
+                                               device_id);
+    gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+  }
+
+  return result;
 }

--- a/src/input.h
+++ b/src/input.h
@@ -12,4 +12,7 @@ void acquire_grab (GromitData *data, GdkDevice *dev);
 void toggle_grab  (GromitData *data, GdkDevice *dev);
 gint snoop_key_press (GtkWidget *grab_widget, GdkEventKey *event, gpointer func_data);
 
+guint grab_key(GromitData *data, gint device_id, const char *key, int num_modifiers, gpointer key_modifiers, gpointer mask);
+guint ungrab_key(GromitData *data, gint device_id, const char *key, int num_modifiers, gpointer key_modifiers);
+
 #endif

--- a/src/input.h
+++ b/src/input.h
@@ -14,5 +14,6 @@ gint snoop_key_press (GtkWidget *grab_widget, GdkEventKey *event, gpointer func_
 
 guint grab_key(GromitData *data, gint device_id, const char *key, int num_modifiers, gpointer key_modifiers, gpointer mask);
 guint ungrab_key(GromitData *data, gint device_id, const char *key, int num_modifiers, gpointer key_modifiers);
+gint get_keyboard_id(GdkDisplay *diplay, GdkDevice *device);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -1195,8 +1195,8 @@ gchar *key2string(GromitLookupKey key)
   
   // to identify buttons 1-10 we need two bytes (two char)
   guint buttons = key.state.buttons;
-  gchar buttons_low = key.state.buttons & 255; // 1-8
-  gchar buttons_high = key.state.buttons >> 8 & 255; // 9-10
+  gchar buttons_low = key.state.buttons & 0xFF; // 1-8
+  gchar buttons_high = (key.state.buttons >> 8) & 0xFF; // 9-10
 
   result[len + 1] = buttons_high + 48;
   result[len + 2] = buttons_low + 48;

--- a/src/main.c
+++ b/src/main.c
@@ -1171,7 +1171,6 @@ gchar *key2string(GromitLookupKey key)
   result[len] = 124;
   
   // to identify buttons 1-10 we need two bytes (two char)
-  guint buttons = key.state.buttons;
   gchar buttons_low = key.state.buttons & 0xFF; // 1-8
   gchar buttons_high = (key.state.buttons >> 8) & 0xFF; // 9-10
 

--- a/src/main.c
+++ b/src/main.c
@@ -699,26 +699,11 @@ void setup_main_app (GromitData *data, int argc, char ** argv)
   */
   if (data->hot_keyval)
     {
-      GdkKeymap    *keymap;
-      GdkKeymapKey *keys;
-      gint          n_keys;
-      guint         keyval;
-
-      if (strlen (data->hot_keyval) > 0 &&
-          strcasecmp (data->hot_keyval, "none") != 0)
+      data->hot_keycode = find_keycode(data->display, data->hot_keyval);
+      if(!data->hot_keycode)
         {
-          keymap = gdk_keymap_get_for_display (data->display);
-          keyval = gdk_keyval_from_name (data->hot_keyval);
-
-          if (!keyval || !gdk_keymap_get_entries_for_keyval (keymap, keyval,
-                                                             &keys, &n_keys))
-            {
-              g_printerr ("cannot find the key \"%s\"\n", data->hot_keyval);
-              exit (1);
-            }
-
-          data->hot_keycode = keys[0].keycode;
-          g_free (keys);
+          g_printerr ("cannot find the key \"%s\"\n", data->hot_keyval);
+          exit (1);
         }
     }
 
@@ -727,27 +712,12 @@ void setup_main_app (GromitData *data, int argc, char ** argv)
   */
   if (data->undo_keyval)
     {
-      GdkKeymap    *keymap;
-      GdkKeymapKey *keys;
-      gint          n_keys;
-      guint         keyval;
-
-      if (strlen (data->undo_keyval) > 0 &&
-          strcasecmp (data->undo_keyval, "none") != 0)
+      data->undo_keycode = find_keycode(data->display, data->undo_keyval);
+      if(!data->undo_keycode)
         {
-          keymap = gdk_keymap_get_for_display (data->display);
-          keyval = gdk_keyval_from_name (data->undo_keyval);
-
-          if (!keyval || !gdk_keymap_get_entries_for_keyval (keymap, keyval,
-                                                             &keys, &n_keys))
-            {
-              g_printerr ("cannot find the key \"%s\"\n", data->undo_keyval);
-              exit (1);
-            }
-
-          data->undo_keycode = keys[0].keycode;
-          g_free (keys);
-        }
+          g_printerr ("cannot find the key \"%s\"\n", data->undo_keyval);
+          exit (1);
+        }        
     }
 
 
@@ -1226,5 +1196,31 @@ gchar *key2string(GromitLookupKey key)
   result[len + 7] = keys4 + 48;
   result[len + 8] = 0;
 
+  return result;
+}
+
+guint find_keycode(GdkDisplay *display, const gchar *keyval)
+{
+  GdkKeymap *keymap;
+  GdkKeymapKey *keys;
+  gint n_keys;
+  guint gdk_keyval, result = 0;
+
+  if (strlen(keyval) > 0 &&
+      strcasecmp(keyval, "none") != 0)
+  {
+    keymap = gdk_keymap_get_for_display(display);
+    gdk_keyval = gdk_keyval_from_name(keyval);
+
+    if (!gdk_keyval || !gdk_keymap_get_entries_for_keyval(keymap, gdk_keyval,
+                                                          &keys, &n_keys))
+    {
+      g_printerr("cannot find the key \"%s\"\n", keyval);
+      return 0;
+    }
+
+    result = keys[0].keycode;
+    g_free(keys);
+  }
   return result;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -381,7 +381,7 @@ void select_tool (GromitData *data,
   		  cursor,
   		  GDK_CURRENT_TIME);
 
-  devdata->state = state;
+  data->state = state;
   devdata->lastslave = slave_device;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -501,10 +501,13 @@ void main_do_event (GdkEventAny *event,
 		    GromitData  *data)
 {
   guint keycode = ((GdkEventKey *) event)->hardware_keycode;
+  guint32 keyunicode = gdk_keyval_to_unicode(((GdkEventKey *)event)->keyval);
   if ((event->type == GDK_KEY_PRESS ||
        event->type == GDK_KEY_RELEASE) &&
       event->window == data->root &&
-      (keycode == data->hot_keycode || keycode == data->undo_keycode))
+      (keycode == data->hot_keycode || keycode == data->undo_keycode ||
+      (keyunicode >= GDK_KEY_a && keyunicode <= GDK_KEY_z) ||
+       (keyunicode >= GDK_KEY_A && keyunicode <= GDK_KEY_Z)))
     {
       /* redirect the event to our main window, so that GTK+ doesn't
        * throw it away (there is no GtkWidget for the root window...)
@@ -633,6 +636,10 @@ void setup_main_app (GromitData *data, int argc, char ** argv)
 		    G_CALLBACK (on_buttonpress), data);
   g_signal_connect (data->win, "button_release_event",
 		    G_CALLBACK (on_buttonrelease), data);
+  g_signal_connect(data->win, "key-press-event",
+        G_CALLBACK(on_keypress), data);
+  g_signal_connect(data->win, "key-release-event",
+        G_CALLBACK(on_keyrelease), data);
   /* disconnect previously defined selection handlers */
   g_signal_handlers_disconnect_by_func (data->win, 
 					G_CALLBACK (on_clientapp_selection_get),

--- a/src/main.c
+++ b/src/main.c
@@ -256,7 +256,8 @@ void select_tool (GromitData *data,
 		  GromitState state)
 {
   guint buttons = 0, modifier = 0, slave_len = 0, len = 0, default_len = 0;
-  guint req_buttons = 0, req_modifier = 0;
+  gulong keys = 0;
+  guint req_buttons = 0, req_modifier = 0, req_keys = 0;
   guint i, j, success = 0;
   GromitPaintContext *context = NULL;
   GromitLookupKey keySlave = {}, keyName = {}, keyDefault = {};
@@ -277,6 +278,7 @@ void select_tool (GromitData *data,
       /* Extract Button/Modifiers from state (see GdkModifierType) */
       req_buttons = state.buttons;
       req_modifier = state.modifiers;
+      req_keys = state.keys;
 
       /*
 	Iterate i up until <= req_buttons.
@@ -300,17 +302,22 @@ void select_tool (GromitData *data,
 	  if(i > 0 && (buttons == 0 || buttons != i))
 	      continue;
 
+    keys = req_keys;
+
           j=-1;
           do
             {
               j++;
               modifier = req_modifier & ((1 << j)-1);
-              keySlave.state.buttons = buttons;
-              keySlave.state.modifiers = modifier;
-              keyName.state.buttons = buttons;
-              keyName.state.modifiers = modifier;
-              keyDefault.state.buttons = buttons;
-              keyDefault.state.modifiers = modifier;
+              
+              GromitState newState = {};
+              newState.buttons = buttons;
+              newState.modifiers = modifier;
+              newState.keys = keys;
+
+              keySlave.state = newState;
+              keyName.state = newState;
+              keyDefault.state = newState;
 
 	            if(data->debug)
                 g_printerr("DEBUG: select_tool looking up context for '%s' attached to '%s'\n", key2string(keySlave), key2string(keyName));
@@ -1189,7 +1196,7 @@ gchar *key2string(GromitLookupKey key)
   gchar *result;
 
   len = strlen(key.name);
-  result = g_strndup(key.name, len + 4);
+  result = g_strndup(key.name, len + 8);
 
   result[len] = 124;
   
@@ -1198,10 +1205,26 @@ gchar *key2string(GromitLookupKey key)
   gchar buttons_low = key.state.buttons & 0xFF; // 1-8
   gchar buttons_high = (key.state.buttons >> 8) & 0xFF; // 9-10
 
+  // there are 26 keys, we need four bytes (four char) if we 
+  // want to allow all 26 keys pressed at the same time
+  // although the OS doesn't allow all keys pressed
+  gulong keys = key.state.keys & 0x7FFFFFF; // limit to 26 bits
+  gchar keys1 = keys & 0xFF;
+  keys = keys >> 8;
+  gchar keys2 = keys & 0xFF;
+  keys = keys >> 8;
+  gchar keys3 = keys & 0xFF;
+  keys = keys >> 8;
+  gchar keys4 = keys & 0xFF;
+
   result[len + 1] = buttons_high + 48;
   result[len + 2] = buttons_low + 48;
   result[len + 3] = key.state.modifiers + 48;
-  result[len + 4] = 0;
+  result[len + 4] = keys1 + 48;
+  result[len + 5] = keys2 + 48;
+  result[len + 6] = keys3 + 48;
+  result[len + 7] = keys4 + 48;
+  result[len + 8] = 0;
 
   return result;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -40,7 +40,9 @@
                               GDK_BUTTON_RELEASE_MASK | \
                               GDK_POINTER_MOTION_MASK )
 
-#define GROMIT_WINDOW_EVENTS ( GROMIT_MOUSE_EVENTS | GDK_EXPOSURE_MASK)
+#define GROMIT_KEYBOARD_EVENTS (GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK)
+
+#define GROMIT_WINDOW_EVENTS ( GROMIT_MOUSE_EVENTS | GROMIT_KEYBOARD_EVENTS | GDK_EXPOSURE_MASK)
 
 /* Atoms used to control Gromit */
 #define GA_CONTROL    gdk_atom_intern ("Gromit/control", FALSE)
@@ -93,14 +95,15 @@ typedef struct
 
 
 typedef struct {
-    guint buttons;
-    guint modifiers;
+  guint buttons;
+  guint modifiers;
+  gulong keys;
 } GromitState;
 
 
 typedef struct {
-    GromitState state;
-    gchar *name;
+  GromitState state;
+  gchar *name;
 } GromitLookupKey;
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -112,7 +112,6 @@ typedef struct
   GList*       coordlist;
   GdkDevice*   device;
   guint        index;
-  GromitState  state;
   GromitPaintContext *cur_context;
   gboolean     is_grabbed;
   gboolean     was_grabbed;
@@ -147,6 +146,8 @@ typedef struct
   GromitPaintContext *default_eraser;
  
   GHashTable  *tool_config;
+
+  GromitState state;
 
   cairo_surface_t *backbuffer;
   /* Auxiliary backbuffer for tools like LINE or RECT */

--- a/src/main.h
+++ b/src/main.h
@@ -207,4 +207,6 @@ void indicate_active(GromitData *data, gboolean YESNO);
 gboolean compare_state(GromitState lhs, GromitState rhs);
 gchar *key2string(GromitLookupKey key);
 
+guint find_keycode(GdkDisplay *display, const gchar *keyval);
+
 #endif

--- a/src/main.h
+++ b/src/main.h
@@ -37,7 +37,8 @@
 
 #define GROMIT_MOUSE_EVENTS ( GDK_BUTTON_MOTION_MASK | \
                               GDK_BUTTON_PRESS_MASK | \
-                              GDK_BUTTON_RELEASE_MASK )
+                              GDK_BUTTON_RELEASE_MASK | \
+                              GDK_POINTER_MOTION_MASK )
 
 #define GROMIT_WINDOW_EVENTS ( GROMIT_MOUSE_EVENTS | GDK_EXPOSURE_MASK)
 
@@ -90,6 +91,19 @@ typedef struct
   gdouble         pressure;
 } GromitPaintContext;
 
+
+typedef struct {
+    guint buttons;
+    guint modifiers;
+} GromitState;
+
+
+typedef struct {
+    GromitState state;
+    gchar *name;
+} GromitLookupKey;
+
+
 typedef struct
 {
   gdouble      lastx;
@@ -98,7 +112,7 @@ typedef struct
   GList*       coordlist;
   GdkDevice*   device;
   guint        index;
-  guint        state;
+  GromitState  state;
   GromitPaintContext *cur_context;
   gboolean     is_grabbed;
   gboolean     was_grabbed;
@@ -168,7 +182,7 @@ void show_window (GromitData *data);
 
 void parse_print_help (gpointer key, gpointer value, gpointer user_data);
 
-void select_tool (GromitData *data, GdkDevice *device, GdkDevice *slave_device, guint state);
+void select_tool (GromitData *data, GdkDevice *device, GdkDevice *slave_device, GromitState state);
 
 void copy_surface (cairo_surface_t *dst, cairo_surface_t *src);
 void swap_surfaces (cairo_surface_t *a, cairo_surface_t *b);
@@ -185,5 +199,8 @@ GromitPaintContext *paint_context_new (GromitData *data, GromitPaintType type,
 void paint_context_free (GromitPaintContext *context);
 
 void indicate_active(GromitData *data, gboolean YESNO);
+
+gboolean compare_state(GromitState lhs, GromitState rhs);
+gchar *key2string(GromitLookupKey key);
 
 #endif


### PR DESCRIPTION
Hi,
I was able to implement a-z usage.
Users can configure like this
```
"default"[a] = "lavender Pen";
"default"[B] = "blue Rect";
```
When users press Hotkey all a-z keys are grabbed and they won't be able to type, but pressing the Hotkey again will release them so users can type back.
Case is insensitive, lower and upper cases do the same action, the last one configured will be used.

This is a continuation of #199 

Let me know if you have any questions.
Bruno
