### PR TITLE
coordlist_ops: adjust memcpy call for macro

### DIFF
--- a/src/coordlist_ops.c
+++ b/src/coordlist_ops.c
@@ -270,7 +270,7 @@ static gfloat angle_deg_snap(gfloat angle,
 // -------------------- 2D affine transformations --------------------
 
 static void unity2D(trans2D *m) {
-    memcpy(m->m, (gfloat[6]){1.0, 0.0, 0.0, 0.0, 1.0, 0.0}, sizeof(gfloat[6]));
+    memcpy(m->m, ((gfloat[6]){1.0, 0.0, 0.0, 0.0, 1.0, 0.0}), sizeof(gfloat[6]));
 }
 
 static void rotate2D(gfloat angle, trans2D *m) {


### PR DESCRIPTION
In some SSP implementations - like NetBSD ssp(3) - memcpy(3) can be a macro and the build will fail because the macro will see 8 arguments instead of 3.

Actual build error, included for convenience: 

```
[ 69%] Building C object CMakeFiles/gromit-mpx.dir/src/coordlist_ops.c.o
.../pkgsrc/wip/gromit-mpx/work/gromit-mpx-1.7.0/src/coordlist_ops.c: In function 'unity2D':
.../pkgsrc/wip/gromit-mpx/work/gromit-mpx-1.7.0/src/coordlist_ops.c:273:78: error: macro "memcpy" passed 8 arguments, but takes just 3
  273 |     memcpy(m->m, (gfloat[6]){1.0, 0.0, 0.0, 0.0, 1.0, 0.0}, sizeof(gfloat[6]));
      |                                                                              ^
In file included from /usr/include/string.h:128,
                 from .../pkgsrc/wip/gromit-mpx/work/gromit-mpx-1.7.0/src/coordlist_ops.c:26:
/usr/include/ssp/string.h:95: note: macro "memcpy" defined here
   95 | #define memcpy(dst, src, len) __ssp_bos_check3(memcpy, dst, src, len)
      |
.../pkgsrc/wip/gromit-mpx/work/gromit-mpx-1.7.0/src/coordlist_ops.c:273:5: warning: statement with no effect [-Wunused-value]
  273 |     memcpy(m->m, (gfloat[6]){1.0, 0.0, 0.0, 0.0, 1.0, 0.0}, sizeof(gfloat[6]));
      |     ^~~~~~
```

I have noticed it while packaging gromit-mpx in [pkgsrc](https://www.pkgsrc.org) on [NetBSD](https://www.NetBSD.org/).
