### PR TITLE
Added CIRCLE support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ Makefile.in
 /flatpak/.flatpak-builder/
 /flatpak/build-dir/
 /.cache/
+*~
+*.swp
+*.bak

--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ avma <avi.markovitz@gmail.com>
 godmar <godmar@gmail.com>
 Ashwin Rajesh <46510831+VanillaViking@users.noreply.github.com>
 Pascal Niklaus <pascal.niklaus@ieu.uzh.ch>
+Marcin Orlowski <mail@marcinOrlowski.com>

--- a/README.md
+++ b/README.md
@@ -212,6 +212,39 @@ A `RECT`-tool draws rectangles.
 
     "red Rectangle" = RECT (color = "red");
 
+A `CIRCLE`-tool draws circles. You can create both outlined and filled circles.
+
+CIRCLE tool
+
+For a simple outlined circle, just specify the color and size:
+
+```
+"blue Circle" = CIRCLE (color="blue" size=3);
+```
+
+For a filled circle, add the `fillcolor` parameter to define the interior color while the
+outline uses the regular `color` value:
+
+```
+"red Filled Circle" = CIRCLE (color="black" size=3 fillcolor="red");
+```
+
+For semi-transparent fills, use the rgba() format to specify opacity (the alpha value ranges from 
+0.0 to 1.0):
+
+```
+"semi-transparent blue Circle" = CIRCLE (color="black" size=3 fillcolor="rgba(0, 0, 255, 0.5)");
+```
+
+Tip: If you define outlined and filled circles with the same hotkeys but different modifiers
+(e.g., `ALT` for outlined, `ALT`+`SHIFT` for filled), you can toggle between circle types on
+the fly by pressing or releasing the modifier key (`SHIFT`) while drawing:
+
+```
+"default"[ALT] = "blue Circle";              # Outlined circle with ALT
+"default"[ALT,SHIFT] = "red Filled Circle";  # Filled circle with ALT+SHIFT
+```
+
 A `SMOOTH`-tool that behaves like `PEN` except that it produces smoothed curves.
 The degree of smoothing can be specified using `simplify=N`. `N` can
 be imagined as approximate pixel range around the resulting line 

--- a/data/gromit-mpx.cfg
+++ b/data/gromit-mpx.cfg
@@ -29,6 +29,14 @@
 
 "red Orthogonal" = ORTHOGONAL (color="red" size=5 simplify=15 radius=20 minlen=50 snap=40);
 
+"blue Circle" = CIRCLE (color="blue" size=3);
+
+"red Filled Circle" = CIRCLE (color="black" size=3 fillcolor="red");
+
+# Note: For transparency, use the rgba() format (values from 0.0 to 1.0 for alpha).
+# The hex format with alpha (#RRGGBBAA) is not supported.
+"semi-transparent Circle" = CIRCLE (color="black" size=3 fillcolor="rgba(255, 0, 0, 0.5)");
+
 #
 # Tool mappings to input devices. Not all tools are mapped in this config.
 #
@@ -37,7 +45,10 @@
 "default"[SHIFT] = "blue Pen";					
 "default"[CONTROL] = "yellow Pen";				
 "default"[2] = "green Marker";					
-"default"[Button3] = "Eraser";					
+"default"[Button3] = "Eraser";
+"default"[ALT] = "blue Circle";
+"default"[ALT,SHIFT] = "red Filled Circle";
+"default"[ALT,CONTROL] = "semi-transparent Circle";					
 
 #
 # Hot key / undo key.

--- a/src/config.c
+++ b/src/config.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * Gromit-MPX -- a program for painting on the screen
  *
  * Gromit Copyright (C) 2000 Simon Budig <Simon.Budig@unix-ag.org>
@@ -124,6 +124,7 @@ enum tool_arguments {
   SYM_RADIUS,
   SYM_SIMPLIFY,
   SYM_SNAP,
+  SYM_FILLCOLOR,
 };
 
 /*
@@ -163,6 +164,7 @@ gboolean parse_config (GromitData *data)
 
   GromitPaintType type;
   GdkRGBA *fg_color=NULL;
+  GdkRGBA *fill_color=NULL;
   guint width, minwidth, maxwidth;
   gfloat arrowsize;
   guint minlen, maxangle, radius, simplify, snapdist;
@@ -216,6 +218,7 @@ gboolean parse_config (GromitData *data)
   g_scanner_scope_add_symbol (scanner, 0, "ORTHOGONAL",(gpointer) GROMIT_ORTHOGONAL);
   g_scanner_scope_add_symbol (scanner, 0, "ERASER",    (gpointer) GROMIT_ERASER);
   g_scanner_scope_add_symbol (scanner, 0, "RECOLOR",   (gpointer) GROMIT_RECOLOR);
+  g_scanner_scope_add_symbol (scanner, 0, "CIRCLE",    (gpointer) GROMIT_CIRCLE);
   g_scanner_scope_add_symbol (scanner, 0, "HOTKEY",               HOTKEY_SYMBOL_VALUE);
   g_scanner_scope_add_symbol (scanner, 0, "UNDOKEY",              UNDOKEY_SYMBOL_VALUE);
 
@@ -240,6 +243,7 @@ gboolean parse_config (GromitData *data)
   g_scanner_scope_add_symbol (scanner, 2, "minlen",    (gpointer) SYM_MINLEN);
   g_scanner_scope_add_symbol (scanner, 2, "simplify",  (gpointer) SYM_SIMPLIFY);
   g_scanner_scope_add_symbol (scanner, 2, "snap",      (gpointer) SYM_SNAP);
+  g_scanner_scope_add_symbol (scanner, 2, "fillcolor", (gpointer) SYM_FILLCOLOR);
 
   g_scanner_set_scope (scanner, 0);
   scanner->config->scope_0_fallback = 0;
@@ -283,6 +287,7 @@ gboolean parse_config (GromitData *data)
           maxangle = 15;
           simplify = 10;
           snapdist = 0;
+          fill_color = NULL;
           fg_color = data->red;
 
           if (token == G_TOKEN_SYMBOL)
@@ -310,6 +315,7 @@ gboolean parse_config (GromitData *data)
                   snapdist = context_template->snapdist;
                   minwidth = context_template->minwidth;
 		  maxwidth = context_template->maxwidth;
+                  fill_color = context_template->fill_color;
                   fg_color = context_template->paint_color;
                 }
               else
@@ -449,6 +455,30 @@ gboolean parse_config (GromitData *data)
                           if (isnan(v)) goto cleanup;
                           snapdist = v;
                         }
+                      else if ((intptr_t) scanner->value.v_symbol == SYM_FILLCOLOR)
+                        {
+                          token = g_scanner_get_next_token (scanner);
+                          if (token != G_TOKEN_EQUAL_SIGN)
+                            {
+                              g_printerr ("Missing \"=\"... aborting\n");
+                              goto cleanup;
+                            }
+                          token = g_scanner_get_next_token (scanner);
+                          if (token != G_TOKEN_STRING)
+                            {
+                              g_printerr ("Missing Fill Color (string)... "
+                                          "aborting\n");
+                              goto cleanup;
+                            }
+                          fill_color = g_malloc (sizeof (GdkRGBA));
+                          if (!gdk_rgba_parse (fill_color, scanner->value.v_string))
+                            {
+                              g_printerr ("Unable to parse fill color. "
+                                          "Fill will not be applied.\n");
+                              g_free (fill_color);
+                              fill_color = NULL;
+                            }
+                        }
 		      else
                         {
                           g_printerr ("Unknown tool type?????\n");
@@ -478,6 +508,7 @@ gboolean parse_config (GromitData *data)
                                        arrowsize, arrowtype,
                                        simplify, radius, maxangle, minlen, snapdist,
                                        minwidth, maxwidth);
+          context->fill_color = fill_color;
           g_hash_table_insert (data->tool_config, name, context);
         }
       else if (token == G_TOKEN_SYMBOL &&

--- a/src/drawing.c
+++ b/src/drawing.c
@@ -1,4 +1,3 @@
-
 #include <math.h>
 #include "drawing.h"
 #include "main.h"
@@ -24,21 +23,21 @@ void draw_line (GromitData *data,
       cairo_set_line_width(devdata->cur_context->paint_ctx, data->maxwidth);
       cairo_set_line_cap(devdata->cur_context->paint_ctx, CAIRO_LINE_CAP_ROUND);
       cairo_set_line_join(devdata->cur_context->paint_ctx, CAIRO_LINE_JOIN_ROUND);
- 
+
       cairo_move_to(devdata->cur_context->paint_ctx, x1, y1);
       cairo_line_to(devdata->cur_context->paint_ctx, x2, y2);
       cairo_stroke(devdata->cur_context->paint_ctx);
 
       data->modified = 1;
 
-      gdk_window_invalidate_rect(gtk_widget_get_window(data->win), &rect, 0); 
+      gdk_window_invalidate_rect(gtk_widget_get_window(data->win), &rect, 0);
     }
 
   data->painted = 1;
 }
 
 
-void draw_arrow (GromitData *data, 
+void draw_arrow (GromitData *data,
 		 GdkDevice *dev,
 		 gint x1, gint y1,
 		 gfloat width,
@@ -79,7 +78,7 @@ void draw_arrow (GromitData *data,
       cairo_set_line_width(devdata->cur_context->paint_ctx, 1);
       cairo_set_line_cap(devdata->cur_context->paint_ctx, CAIRO_LINE_CAP_ROUND);
       cairo_set_line_join(devdata->cur_context->paint_ctx, CAIRO_LINE_JOIN_ROUND);
- 
+
       cairo_move_to(devdata->cur_context->paint_ctx, arrowhead[0].x, arrowhead[0].y);
       cairo_line_to(devdata->cur_context->paint_ctx, arrowhead[1].x, arrowhead[1].y);
       cairo_line_to(devdata->cur_context->paint_ctx, arrowhead[2].x, arrowhead[2].y);
@@ -96,12 +95,53 @@ void draw_arrow (GromitData *data,
       cairo_stroke(devdata->cur_context->paint_ctx);
 
       gdk_cairo_set_source_rgba(devdata->cur_context->paint_ctx, devdata->cur_context->paint_color);
-    
+
       data->modified = 1;
 
-      gdk_window_invalidate_rect(gtk_widget_get_window(data->win), &rect, 0); 
+      gdk_window_invalidate_rect(gtk_widget_get_window(data->win), &rect, 0);
     }
 
   data->painted = 1;
 }
 
+
+void draw_circle (GromitData *data,
+                 GdkDevice *dev,
+                 gint x, gint y,
+                 gfloat radius)
+{
+  GdkRectangle rect;
+  GromitDeviceData *devdata = g_hash_table_lookup(data->devdatatable, dev);
+
+  /* Iinvalidation rectangle */
+  rect.x = x - radius - data->maxwidth / 2;
+  rect.y = y - radius - data->maxwidth / 2;
+  rect.width = 2 * radius + data->maxwidth;
+  rect.height = 2 * radius + data->maxwidth;
+
+  if (devdata->cur_context->paint_ctx)
+    {
+      cairo_set_line_width(devdata->cur_context->paint_ctx, data->maxwidth);
+      cairo_set_line_cap(devdata->cur_context->paint_ctx, CAIRO_LINE_CAP_ROUND);
+      cairo_set_line_join(devdata->cur_context->paint_ctx, CAIRO_LINE_JOIN_ROUND);
+
+      if (devdata->cur_context->fill_color)
+        {
+          gdk_cairo_set_source_rgba(devdata->cur_context->paint_ctx, devdata->cur_context->fill_color);
+
+          cairo_arc(devdata->cur_context->paint_ctx, x, y, radius, 0, 2 * M_PI);
+          cairo_fill(devdata->cur_context->paint_ctx);
+
+          gdk_cairo_set_source_rgba(devdata->cur_context->paint_ctx, devdata->cur_context->paint_color);
+        }
+
+      cairo_arc(devdata->cur_context->paint_ctx, x, y, radius, 0, 2 * M_PI);
+      cairo_stroke(devdata->cur_context->paint_ctx);
+
+      data->modified = 1;
+
+      gdk_window_invalidate_rect(gtk_widget_get_window(data->win), &rect, 0);
+    }
+
+  data->painted = 1;
+}

--- a/src/drawing.h
+++ b/src/drawing.h
@@ -18,5 +18,6 @@ typedef struct
 
 void draw_line (GromitData *data, GdkDevice *dev, gint x1, gint y1, gint x2, gint y2);
 void draw_arrow (GromitData *data, GdkDevice *dev, gint x1, gint y1, gfloat width, gfloat direction);
+void draw_circle (GromitData *data, GdkDevice *dev, gint x, gint y, gfloat radius);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -109,6 +109,8 @@ void paint_context_print (gchar *name,
       g_printerr ("Eraser,     "); break;
     case GROMIT_RECOLOR:
       g_printerr ("Recolor,    "); break;
+    case GROMIT_CIRCLE:
+      g_printerr ("Circle,     "); break;
     default:
       g_printerr ("UNKNOWN,    "); break;
   }
@@ -142,6 +144,11 @@ void paint_context_print (gchar *name,
       g_printerr(" radius: %u, minlen: %u, maxangle: %u ",
                  context->radius, context->minlen, context->maxangle);
     }
+  if (context->type == GROMIT_CIRCLE)
+    {
+      if (context->fill_color)
+        g_printerr(" fillcolor: %s, ", gdk_rgba_to_string(context->fill_color));
+    }
   g_printerr ("color: %s\n", gdk_rgba_to_string(context->paint_color));
 }
 
@@ -149,6 +156,8 @@ void paint_context_print (gchar *name,
 void paint_context_free (GromitPaintContext *context)
 {
   cairo_destroy(context->paint_ctx);
+  if (context->fill_color)
+    g_free(context->fill_color);
   g_free (context);
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -69,7 +69,8 @@ typedef enum
   GROMIT_SMOOTH,
   GROMIT_ORTHOGONAL,
   GROMIT_ERASER,
-  GROMIT_RECOLOR
+  GROMIT_RECOLOR,
+  GROMIT_CIRCLE
 } GromitPaintType;
 
 typedef enum
@@ -93,6 +94,7 @@ typedef struct
   guint           simplify;
   guint           snapdist;
   GdkRGBA         *paint_color;
+  GdkRGBA         *fill_color;
   cairo_t         *paint_ctx;
   gdouble         pressure;
 } GromitPaintContext;


### PR DESCRIPTION
Adds support for `CIRCLE` as outline

![circle](https://github.com/user-attachments/assets/d5050f6b-789f-4a11-b8b5-73e245b208ba)

or filled variant. All colors (and alpha) configurable separately

![filled](https://github.com/user-attachments/assets/3fc0ce1e-5a46-4f38-b871-d54f2d0b5110)
