### PR TITLE
Config: Allow nesting config files in common gromit-mpx directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ MPX setup.
 Gromit-MPX is configurable via the file `gromit-mpx.cfg` in the
 directory defined by `$XDG_CONFIG_HOME` (usually `~/.config` or
 `~/.var/app/net.christianbeier.Gromit-MPX/config/` if you installed
-the Flatpak). Here you can specify which Device/Button/Modifier
+the Flatpak). Alternatively, the file can be placed in a `gromit-mpx`
+subdirectory. Here you can specify which Device/Button/Modifier
 combination invokes which tool. See the copy of `gromit-mpx.cfg`
 distributed with this program for an example. An overview on the syntax:
 

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -937,7 +937,7 @@ void on_edit_config(GtkMenuItem *menuitem,
       Check if user config does not exist or is empty.
       If so, copy system config to user config.
     */
-    gchar *user_config_path = g_strjoin (G_DIR_SEPARATOR_S, g_get_user_config_dir(), "gromit-mpx.cfg", NULL);
+    gchar *user_config_path = get_config_filename("gromit-mpx.cfg");
     GFile *user_config_file = g_file_new_for_path(user_config_path);
 
     guint64 user_config_size = 0;

--- a/src/config.c
+++ b/src/config.c
@@ -149,6 +149,20 @@ gfloat parse_get_float(GScanner *scanner, const gchar *msg)
 }
 
 
+gchar *get_config_filename(const gchar *file)
+{
+  const gchar *config = g_get_user_config_dir();
+  gchar *path = g_build_filename(config, "gromit-mpx", NULL);
+  if (!g_file_test(path, G_FILE_TEST_IS_DIR)) {
+    g_free(path);
+    path = g_strdup(config);
+  }
+  gchar *full = g_build_filename(path, file, NULL);
+  g_free(path);
+  return full;
+}
+
+
 gboolean parse_config (GromitData *data)
 {
   gboolean status = FALSE;
@@ -169,8 +183,7 @@ gboolean parse_config (GromitData *data)
   GromitArrowType arrowtype;
 
   /* try user config location */
-  filename = g_strjoin (G_DIR_SEPARATOR_S,
-                        g_get_user_config_dir(), "gromit-mpx.cfg", NULL);
+  filename = get_config_filename("gromit-mpx.cfg");
   if ((file = open(filename, O_RDONLY)) < 0)
       g_print("Could not open user config %s: %s\n", filename, g_strerror (errno));
   else
@@ -686,8 +699,7 @@ int parse_args (int argc, char **argv, GromitData *data)
 
 void read_keyfile(GromitData *data)
 {
-    gchar *filename = g_strjoin (G_DIR_SEPARATOR_S,
-				 g_get_user_config_dir(), "gromit-mpx.ini", NULL);
+    gchar *filename = get_config_filename("gromit-mpx.ini");
 
     /*
       set defaults
@@ -722,8 +734,7 @@ void read_keyfile(GromitData *data)
 
 void write_keyfile(GromitData *data)
 {
-    gchar *filename = g_strjoin (G_DIR_SEPARATOR_S,
-				 g_get_user_config_dir(), "gromit-mpx.ini", NULL);
+    gchar *filename = get_config_filename("gromit-mpx.ini");
 
     GError *error = NULL;
     GKeyFile *key_file = g_key_file_new ();

--- a/src/config.h
+++ b/src/config.h
@@ -53,4 +53,6 @@ void read_keyfile(GromitData *data);
 
 void write_keyfile(GromitData *data);
 
+gchar *get_config_filename(const gchar *filename);
+
 #endif


### PR DESCRIPTION
This PR organizes gromit-mpx configuration files into their own `gromit-mpx` subdirectory within the `.config` directory to reduce
clutter. 
The previous default location is still supported for backwards compatibility, but if the user creates the `gromit-mpx` directory, it will be used instead.
