### PR TITLE
use root window width/height

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1201,8 +1201,8 @@ int main (int argc, char **argv)
   data->xinerama = gdk_screen_get_n_monitors (data->screen) > 1;
   data->composited = gdk_screen_is_composited (data->screen);
   data->root = gdk_screen_get_root_window (data->screen);
-  data->width = gdk_screen_get_width (data->screen);
-  data->height = gdk_screen_get_height (data->screen);
+  data->width = gdk_window_get_width (data->root);
+  data->height = gdk_window_get_height (data->root);
   data->opacity = DEFAULT_OPACITY;
 
   /*


### PR DESCRIPTION
use root window width/height instead of screen width/height to determine overlay window width/height

should work with any window manager and desktop environment as long as the root window covers the entire available 'desktop' space - which they all always do, i think ??

existing code would create overlay window smaller even than physical screen 1 when used in the config of i3 wm with 2 physical screens with 5 xrandr 'virtual' monitors (https://man.archlinux.org/man/xrandr.1#RandR_version_1.5_options). this pr fixes that so the drawable area/overlay window is as large as the 'desktop'
ie 
```
                    physical screen 1 (UHD)                         physical screen 1 (HD)
+---------------------------------------------------------------+----------------------------+
|                              |                                |                            |
|                              |                                |                            |
|                              |                                |                            |
|        virt monitor 2        |      virt monitor 1            |                            |
|                              |                                |                            |
|                              |                                |                            |
|                              |                                |                            |
+---------------------------------------------------------------+      virt monitor 5        |
|                              |                                |                            |
|                              |                                |                            |
|                              |                                |                            |
|        virt monitor 3        |      virt monitor 4            |                            |
|                              |                                |                            |
|                              |                                |                            |
|                              |                                |                            |
+---------------------------------------------------------------+----------------------------+
```
