### PR TITLE
Fix compatibility with newer CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.10)
 project(gromit-mpx LANGUAGES C)
 include(GNUInstallDirs)
 


### PR DESCRIPTION
CMake 4.0 removed compatibility for CMake < 3.5. This increases to explicitly declare support for up to 3.10 (the oldest non-deprecated version), thereby fixing the build on CMake 4.0.