### PR TITLE
Opacity Handling, Anti-aliasing, Configuration Reloads and Memory Management

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -176,18 +176,23 @@ void on_composited_changed ( GdkScreen *screen,
     {
       // undo shape
       gtk_widget_shape_combine_region(data->win, NULL);
-      // re-apply transparency
-      gtk_widget_set_opacity(data->win, 0.75);
+      // PATCH: honor data->opacity (from .ini / --opacity) instead of
+      // hardcoding 0.75 — preserves user's canvas opacity on compositor
+      // state changes (e.g., under Hyprland/Xwayland).
+      gtk_widget_set_opacity(data->win, data->opacity);
     }
 
   // set anti-aliasing
+  // PATCH: use CAIRO_ANTIALIAS_GOOD instead of SUBPIXEL for composited mode.
+  // SUBPIXEL produces color fringing that reads as "blurry" on Wayland/
+  // Xwayland compositors where subpixel geometry is unpredictable.
   GHashTableIter it;
   gpointer value;
   g_hash_table_iter_init (&it, data->tool_config);
-  while (g_hash_table_iter_next (&it, NULL, &value)) 
+  while (g_hash_table_iter_next (&it, NULL, &value))
     {
       GromitPaintContext *context = value;
-      cairo_set_antialias(context->paint_ctx, data->composited ? CAIRO_ANTIALIAS_SUBPIXEL : CAIRO_ANTIALIAS_NONE);
+      cairo_set_antialias(context->paint_ctx, data->composited ? CAIRO_ANTIALIAS_GOOD : CAIRO_ANTIALIAS_NONE);
     }
       
 
@@ -568,7 +573,22 @@ void on_mainapp_selection_get (GtkWidget          *widget,
   else if (action == GA_CLEAR)
     clear_screen (data);
   else if (action == GA_RELOAD)
-    setup_input_devices(data);
+    {
+      /* PATCH: full config reload — upstream only calls setup_input_devices,
+       * which re-enumerates pointer devices but does NOT re-read the .cfg.
+       * That makes "edit cfg + --reload" a no-op for tool-mapping changes.
+       * Here we free all tool contexts, re-parse the config (rebuilding
+       * tool_config hash), and re-apply device defaults. Drawings in the
+       * backbuffer are untouched — only the tool state gets refreshed. */
+      GHashTableIter it;
+      gpointer value;
+      g_hash_table_iter_init(&it, data->tool_config);
+      while (g_hash_table_iter_next(&it, NULL, &value))
+        paint_context_free(value);
+      g_hash_table_remove_all(data->tool_config);
+      parse_config(data);
+      setup_input_devices(data);
+    }
   else if (action == GA_QUIT)
     gtk_main_quit ();
   else if (action == GA_UNDO)

--- a/src/config.h
+++ b/src/config.h
@@ -46,7 +46,7 @@ int parse_args (int argc, char **argv, GromitData *data);
 #define DEFAULT_UNDOKEY_XFCE "End"
 #endif
 #ifndef DEFAULT_OPACITY
-#define DEFAULT_OPACITY 0.75
+#define DEFAULT_OPACITY 1.0
 #endif
 
 void read_keyfile(GromitData *data);

--- a/src/main.c
+++ b/src/main.c
@@ -73,7 +73,12 @@ GromitPaintContext *paint_context_new (GromitData *data,
   if(!data->composited)
     cairo_set_antialias(context->paint_ctx, CAIRO_ANTIALIAS_NONE);
   else
-    cairo_set_antialias(context->paint_ctx, CAIRO_ANTIALIAS_SUBPIXEL);
+    /* PATCH: CAIRO_ANTIALIAS_GOOD instead of SUBPIXEL.
+     * SUBPIXEL does LCD-geometry AA that assumes a known RGB stripe layout;
+     * under Wayland/Xwayland compositors this geometry is unreliable, so the
+     * color fringes at stroke edges read as "blur". GOOD does grayscale AA —
+     * crisp edges, no color fringing. */
+    cairo_set_antialias(context->paint_ctx, CAIRO_ANTIALIAS_GOOD);
   cairo_set_line_width(context->paint_ctx, width);
   cairo_set_line_cap(context->paint_ctx, CAIRO_LINE_CAP_ROUND);
   cairo_set_line_join(context->paint_ctx, CAIRO_LINE_JOIN_ROUND);
@@ -157,8 +162,14 @@ void paint_context_print (gchar *name,
 void paint_context_free (GromitPaintContext *context)
 {
   cairo_destroy(context->paint_ctx);
-  if (context->fill_color)
-    g_free(context->fill_color);
+  /* PATCH: do NOT g_free(context->fill_color) here. Upstream bug —
+   * config.c COPY syntax (`"foo" = "bar" (...)`) performs a shallow
+   * pointer copy of fill_color at config.c:324, so two entries in
+   * data->tool_config can share the same heap pointer. Freeing it
+   * per-context causes a double-free when iterating the hash table
+   * (GA_RELOAD, on_monitors_changed). The leak is bounded to one
+   * GdkRGBA per unique `fillcolor=` in the cfg (handful of bytes)
+   * and only accumulates on reloads — acceptable trade for safety. */
   g_free (context);
 }
 


### PR DESCRIPTION
This pull request introduces several important bug fixes and improvements to opacity handling, anti-aliasing, configuration reloads, and memory management for the application. The main changes ensure that user preferences are respected, drawing quality is improved on modern compositors, configuration reloads work as expected, and a critical double-free bug is avoided.

**Opacity and anti-aliasing improvements:**
- The default opacity (`DEFAULT_OPACITY`) is now set to `1.0` instead of `0.75`, and dynamic opacity changes now honor user settings from `.ini` or command-line options rather than being hardcoded, preserving user preferences during compositor state changes. [[1]](diffhunk://#diff-c24f78b3519d763901eb9f67b864f01d802d803df1b24faaf154019cf812bf95L49-R49) [[2]](diffhunk://#diff-1d0efcfbefd013aedf0477bd522a1e4506339c5ef239a6ef770f39270747c14cL179-R195)
- Anti-aliasing mode for composited windows is switched from `CAIRO_ANTIALIAS_SUBPIXEL` to `CAIRO_ANTIALIAS_GOOD`, preventing color fringing and improving stroke clarity on Wayland/Xwayland compositors. [[1]](diffhunk://#diff-1d0efcfbefd013aedf0477bd522a1e4506339c5ef239a6ef770f39270747c14cL179-R195) [[2]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L76-R81)

**Configuration reload and memory management:**
- The configuration reload (`GA_RELOAD`) action now fully re-reads the config file and rebuilds the tool configuration, ensuring that changes to tool mappings are applied without requiring a restart.
- A double-free bug is fixed by no longer freeing `context->fill_color` in `paint_context_free`, as multiple tool contexts could share the same pointer due to shallow copies. This trades a small, bounded memory leak for stability.